### PR TITLE
Make DTLS-SRTP and the Extended Master Secret extensions optional and enabled by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     flight_retries: usize,
     handshake_timeout: Duration,
     crypto_provider: CryptoProvider,
+    with_srtp: bool,
+    with_extended_master_secret: bool,
 }
 
 impl Config {
@@ -31,6 +33,8 @@ impl Config {
             flight_retries: 4,
             handshake_timeout: Duration::from_secs(40),
             crypto_provider: None,
+            with_srtp: true,
+            with_extended_master_secret: true,
         }
     }
 
@@ -91,6 +95,18 @@ impl Config {
     pub fn crypto_provider(&self) -> &CryptoProvider {
         &self.crypto_provider
     }
+
+    /// Whether to enable DTLS-SRTP extension (rfc5764).
+    #[inline(always)]
+    pub fn with_srtp(&self) -> bool {
+        self.with_srtp
+    }
+
+    /// Whether to enable Extended Master Secret extension (rfc7627).
+    #[inline(always)]
+    pub fn with_extended_master_secret(&self) -> bool {
+        self.with_extended_master_secret
+    }
 }
 
 /// Builder for DTLS configuration.
@@ -103,6 +119,8 @@ pub struct ConfigBuilder {
     flight_retries: usize,
     handshake_timeout: Duration,
     crypto_provider: Option<CryptoProvider>,
+    with_srtp: bool,
+    with_extended_master_secret: bool,
 }
 
 impl ConfigBuilder {
@@ -176,6 +194,22 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set whether to enable DTLS-SRTP extension (rfc5764).
+    ///
+    /// Defaults to true.
+    pub fn with_srtp(mut self, require: bool) -> Self {
+        self.with_srtp = require;
+        self
+    }
+
+    /// Set whether to enable Extended Master Secret extension (rfc7627)
+    ///
+    /// Defaults to true.
+    pub fn with_extended_master_secret(mut self, require: bool) -> Self {
+        self.with_extended_master_secret = require;
+        self
+    }
+
     /// Build the configuration.
     ///
     /// This validates the crypto provider before returning the configuration.
@@ -218,6 +252,8 @@ impl ConfigBuilder {
             flight_retries: self.flight_retries,
             handshake_timeout: self.handshake_timeout,
             crypto_provider,
+            with_srtp: self.with_srtp,
+            with_extended_master_secret: self.with_extended_master_secret,
         })
     }
 }

--- a/src/message/client_hello.rs
+++ b/src/message/client_hello.rs
@@ -11,6 +11,7 @@ use nom::{Err, IResult};
 use crate::buffer::Buf;
 use crate::crypto::CryptoProvider;
 use crate::util::many1;
+use crate::Config;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientHello {
@@ -44,7 +45,12 @@ impl ClientHello {
     }
 
     /// Add all required extensions for DTLS handshake
-    pub fn with_extensions(mut self, buf: &mut Buf, provider: &CryptoProvider) -> Self {
+    pub fn with_extensions(
+        mut self,
+        buf: &mut Buf,
+        provider: &CryptoProvider,
+        config: &Config,
+    ) -> Self {
         // Clear the extension data buffer
         buf.clear();
 
@@ -75,11 +81,13 @@ impl ClientHello {
         signature_algorithms.serialize(buf);
         ranges.push((ExtensionType::SignatureAlgorithms, start_pos, buf.len()));
 
-        // Add use_srtp extension for DTLS-SRTP support
-        let use_srtp = UseSrtpExtension::default();
-        let start_pos = buf.len();
-        use_srtp.serialize(buf);
-        ranges.push((ExtensionType::UseSrtp, start_pos, buf.len()));
+        if config.with_srtp() {
+            // Add use_srtp extension for DTLS-SRTP support
+            let use_srtp = UseSrtpExtension::default();
+            let start_pos = buf.len();
+            use_srtp.serialize(buf);
+            ranges.push((ExtensionType::UseSrtp, start_pos, buf.len()));
+        }
 
         // // Add session_ticket extension (empty)
         // let start_pos = buf.len();
@@ -97,12 +105,14 @@ impl ClientHello {
             ranges.push((ExtensionType::EncryptThenMac, start_pos, buf.len()));
         }
 
-        let start_pos = buf.len();
-        ranges.push((
-            ExtensionType::ExtendedMasterSecret,
-            start_pos,
-            start_pos, // No data at all
-        ));
+        if config.with_extended_master_secret() {
+            let start_pos = buf.len();
+            ranges.push((
+                ExtensionType::ExtendedMasterSecret,
+                start_pos,
+                start_pos, // No data at all
+            ));
+        }
 
         // Now create all extensions using ranges
         for (extension_type, start, end) in ranges {


### PR DESCRIPTION
Add configuration makes DTLS-SRTP and the Extended Master Secret extensions optional and enabled by default, without affecting existing applications.