### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/algesten/dimpl/security/code-scanning/5](https://github.com/algesten/dimpl/security/code-scanning/5)

To fix the problem, you should add a `permissions:` block to explicitly define the minimum required permissions for the workflow or for the `cargo-deny` job specifically. Since none of the shown steps require write access, the best practice is to set `permissions: contents: read` at the top level (root of the workflow), applying to all jobs. This both resolves the CodeQL warning and reduces the risk of privilege escalation or misuse of the default token.

Specifically:
- Edit `.github/workflows/cargo.yml`
- Insert the following lines after the `name: CI` header (after line 1 and before the `on:` block).
- This will apply to all jobs, including `cargo-deny`.
- No additional imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
