### PR TITLE
fix: dimpl is not compatible with < aws-lc-rs 1.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ spki = "0.7"
 x509-cert = { version = "0.2", default-features = false }
 
 # aws-lc-rs backend
-aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"], optional = true }
+aws-lc-rs = { version = "^1.14", default-features = false, features = ["aws-lc-sys", "prebuilt-nasm"], optional = true }
 
 # RustCrypto backend
 aes-gcm = { version = "0.10", optional = true }


### PR DESCRIPTION
I just tried updating str0m to 0.14. It looks like aws-lc-rs contains some breaking changes on 1.x. I was on aws-lc-rs 1.13.3 because some transitive dependencies. dimpl compiles fine on aws-lc-rs 1.14.x and 1.15.x.

```
error[E0308]: mismatched types
   --> /home/lukas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dimpl-0.2.0/src/crypto/aws_lc_rs/kx_group.rs:72:13
    |
 70 |         agree_ephemeral(
    |         --------------- arguments to this function are incorrect
 71 |             self.private_key,
 72 |             peer_key,
    |             ^^^^^^^^ expected `&UnparsedPublicKey<_>`, found `UnparsedPublicKey<&[u8]>`
    |
    = note: expected reference `&aws_lc_rs::agreement::UnparsedPublicKey<_>`
                  found struct `aws_lc_rs::agreement::UnparsedPublicKey<&[u8]>`
note: function defined here
   --> /home/lukas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-lc-rs-1.13.3/src/agreement/ephemeral.rs:101:8
    |
101 | pub fn agree_ephemeral<B: AsRef<[u8]>, F, R, E>(
    |        ^^^^^^^^^^^^^^^
help: consider borrowing here
    |
 72 |             &peer_key,
    |             +

For more information about this error, try `rustc --explain E0308`.
error: could not compile `dimpl` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:21: dev] Error 101
```