### PR TITLE
Implement Debug for Dtls

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -112,6 +112,10 @@ impl Client {
         Server::new_with_engine(self.engine)
     }
 
+    pub(crate) fn state_name(&self) -> &'static str {
+        self.state.name()
+    }
+
     pub fn handle_packet(&mut self, packet: &[u8]) -> Result<(), Error> {
         self.engine.parse_packet(packet)?;
         self.make_progress()?;
@@ -198,6 +202,27 @@ enum State {
 }
 
 impl State {
+    fn name(&self) -> &'static str {
+        match self {
+            State::SendClientHello => "SendClientHello",
+            State::AwaitHelloVerifyRequest => "AwaitHelloVerifyRequest",
+            State::AwaitServerHello => "AwaitServerHello",
+            State::AwaitCertificate => "AwaitCertificate",
+            State::AwaitServerKeyExchange => "AwaitServerKeyExchange",
+            State::AwaitCertificateRequest => "AwaitCertificateRequest",
+            State::AwaitServerHelloDone => "AwaitServerHelloDone",
+            State::SendCertificate => "SendCertificate",
+            State::SendClientKeyExchange => "SendClientKeyExchange",
+            State::SendCertificateVerify => "SendCertificateVerify",
+            State::SendChangeCipherSpec => "SendChangeCipherSpec",
+            State::SendFinished => "SendFinished",
+            State::AwaitChangeCipherSpec => "AwaitChangeCipherSpec",
+            State::AwaitNewSessionTicket => "AwaitNewSessionTicket",
+            State::AwaitFinished => "AwaitFinished",
+            State::AwaitApplicationData => "AwaitApplicationData",
+        }
+    }
+
     fn make_progress(self, client: &mut Client) -> Result<Self, Error> {
         match self {
             State::SendClientHello => self.send_client_hello(client),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,20 @@ impl Dtls {
     }
 }
 
+impl fmt::Debug for Dtls {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (role, state) = match &self.inner {
+            Some(Inner::Client(c)) => ("Client", c.state_name()),
+            Some(Inner::Server(s)) => ("Server", s.state_name()),
+            None => ("None", ""),
+        };
+        f.debug_struct("Dtls")
+            .field("role", &role)
+            .field("state", &state)
+            .finish()
+    }
+}
+
 /// Output events produced by the DTLS engine when polled.
 pub enum Output<'a> {
     /// A DTLS record to transmit on the wire.

--- a/src/server.rs
+++ b/src/server.rs
@@ -139,6 +139,10 @@ impl Server {
         Client::new_with_engine(self.engine)
     }
 
+    pub(crate) fn state_name(&self) -> &'static str {
+        self.state.name()
+    }
+
     pub fn handle_packet(&mut self, packet: &[u8]) -> Result<(), Error> {
         self.engine.parse_packet(packet)?;
         self.make_progress()?;
@@ -201,6 +205,25 @@ impl Server {
 }
 
 impl State {
+    fn name(&self) -> &'static str {
+        match self {
+            State::AwaitClientHello => "AwaitClientHello",
+            State::SendServerHello => "SendServerHello",
+            State::SendCertificate => "SendCertificate",
+            State::SendServerKeyExchange => "SendServerKeyExchange",
+            State::SendCertificateRequest => "SendCertificateRequest",
+            State::SendServerHelloDone => "SendServerHelloDone",
+            State::AwaitCertificate => "AwaitCertificate",
+            State::AwaitClientKeyExchange => "AwaitClientKeyExchange",
+            State::AwaitCertificateVerify => "AwaitCertificateVerify",
+            State::AwaitChangeCipherSpec => "AwaitChangeCipherSpec",
+            State::AwaitFinished => "AwaitFinished",
+            State::SendChangeCipherSpec => "SendChangeCipherSpec",
+            State::SendFinished => "SendFinished",
+            State::AwaitApplicationData => "AwaitApplicationData",
+        }
+    }
+
     fn make_progress(self, server: &mut Server) -> Result<Self, Error> {
         match self {
             State::AwaitClientHello => self.await_client_hello(server),


### PR DESCRIPTION
## Summary
- Add `Debug` implementation for the main `Dtls` export
- Shows role (Client/Server) and current handshake state
- Avoids exposing sensitive data like keys or certificates

Example output: `Dtls { role: "Client", state: "AwaitServerHello" }`