### PR TITLE
Fix is_known logic for parser filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+ * Fix ClientHello parser failing due to incorrect is_known method logic
+
 # 0.2.5
 
   * Fix ClientHello Parser Failing when too many Cipher Suites #46

--- a/src/message/client_hello.rs
+++ b/src/message/client_hello.rs
@@ -365,7 +365,7 @@ mod tests {
 
         assert_eq!(
             client_hello.extensions.capacity(),
-            ExtensionType::all_known().len(),
+            ExtensionType::all().len(),
             "extensions ArrayVec capacity must match all known ExtensionTypes"
         );
     }

--- a/src/message/extension.rs
+++ b/src/message/extension.rs
@@ -193,12 +193,11 @@ impl ExtensionType {
 
     /// Returns true if this extension type is a known/supported variant.
     pub fn is_known(&self) -> bool {
-        !matches!(self, ExtensionType::Unknown(_))
+        Self::all().contains(self)
     }
 
     /// All known extension types that this implementation handles.
-    #[cfg(test)]
-    pub fn all_known() -> &'static [ExtensionType] {
+    pub fn all() -> &'static [ExtensionType] {
         &[
             ExtensionType::SupportedGroups,
             ExtensionType::EcPointFormats,

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -215,7 +215,7 @@ impl CipherSuite {
 
     /// Returns true if this cipher suite is a known/supported variant.
     pub fn is_known(&self) -> bool {
-        !matches!(self, CipherSuite::Unknown(_))
+        Self::all().contains(self)
     }
 }
 
@@ -243,11 +243,10 @@ impl CompressionMethod {
 
     /// Returns true if this compression method is a known/supported variant.
     pub fn is_known(&self) -> bool {
-        !matches!(self, CompressionMethod::Unknown(_))
+        Self::all().contains(self)
     }
 
     /// All known compression methods.
-    #[cfg(test)]
     pub fn all() -> &'static [CompressionMethod] {
         &[CompressionMethod::Null, CompressionMethod::Deflate]
     }


### PR DESCRIPTION
The is_known methods did not check against all supported types, but against all known types, which may be larger than the supported types. Switch the logic to compare against the supported types.

Also rename the "all_known" method to "all" to match the other existing methods in the code base.

Fixes #49