### PR TITLE
Accept now: Instant in constructor, remove panic in poll_output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Require now: Instant in Dtls::new() instead of panicking
+
 # 0.2.7
 
   * Ensure compiling without features pulls in no deps #52

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fn example_event_loop(mut dtls: Dtls) -> Result<(), dimpl::Error> {
 fn mk_dtls_client() -> Dtls {
     let cert = certificate::generate_self_signed_certificate().unwrap();
     let cfg = Arc::new(Config::default());
-    let mut dtls = Dtls::new(cfg, cert);
+    let mut dtls = Dtls::new(cfg, cert, Instant::now());
     dtls.set_active(true); // client role
     dtls
 }

--- a/fuzz/fuzz_targets/fuzz_dtls_packet.rs
+++ b/fuzz/fuzz_targets/fuzz_dtls_packet.rs
@@ -25,7 +25,7 @@ fuzz_target!(|data: &[u8]| {
     // Test as server (default mode)
     // Servers can receive packets immediately
     {
-        let mut dtls = Dtls::new(Arc::clone(&config), cert.clone());
+        let mut dtls = Dtls::new(Arc::clone(&config), cert.clone(), now);
         // Ignore errors - we're looking for panics, not handling errors
         let _ = dtls.handle_packet(data);
     }
@@ -33,7 +33,7 @@ fuzz_target!(|data: &[u8]| {
     // Test as client
     // Clients need handle_timeout called first to initialize
     {
-        let mut dtls = Dtls::new(Arc::clone(&config), cert);
+        let mut dtls = Dtls::new(Arc::clone(&config), cert, now);
         dtls.set_active(true); // Switch to client mode
 
         // Initialize the client by calling handle_timeout to set up the random and other state

--- a/fuzz/fuzz_targets/fuzz_record_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_record_parse.rs
@@ -16,6 +16,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use std::sync::Arc;
+use std::time::Instant;
 
 use dimpl::{certificate, Config, Dtls};
 
@@ -31,7 +32,8 @@ fuzz_target!(|data: &[u8]| {
     };
 
     let config = Arc::new(Config::default());
-    let mut dtls = Dtls::new(Arc::clone(&config), cert);
+    let now = Instant::now();
+    let mut dtls = Dtls::new(Arc::clone(&config), cert, now);
 
     // Test the input as-is (even small inputs exercise error paths)
     let _ = dtls.handle_packet(data);

--- a/src/crypto/aws_lc_rs/mod.rs
+++ b/src/crypto/aws_lc_rs/mod.rs
@@ -22,12 +22,13 @@
 //! # #[cfg(feature = "rcgen")]
 //! # fn main() {
 //! use std::sync::Arc;
+//! use std::time::Instant;
 //! use dimpl::{Config, Dtls, certificate};
 //!
 //! let cert = certificate::generate_self_signed_certificate().unwrap();
 //! // Implicitly uses aws-lc-rs default provider
 //! let config = Arc::new(Config::default());
-//! let dtls = Dtls::new(config, cert);
+//! let dtls = Dtls::new(config, cert, Instant::now());
 //! # }
 //! # #[cfg(not(feature = "rcgen"))]
 //! # fn main() {}
@@ -39,6 +40,7 @@
 //! # #[cfg(feature = "rcgen")]
 //! # fn main() {
 //! use std::sync::Arc;
+//! use std::time::Instant;
 //! use dimpl::{Config, Dtls, certificate};
 //! use dimpl::crypto::aws_lc_rs;
 //!
@@ -49,7 +51,7 @@
 //!         .build()
 //!         .unwrap()
 //! );
-//! let dtls = Dtls::new(config, cert);
+//! let dtls = Dtls::new(config, cert, Instant::now());
 //! # }
 //! # #[cfg(not(feature = "rcgen"))]
 //! # fn main() {}

--- a/src/crypto/provider.rs
+++ b/src/crypto/provider.rs
@@ -30,6 +30,7 @@
 //! # #[cfg(all(feature = "aws-lc-rs", feature = "rcgen"))]
 //! # fn main() {
 //! use std::sync::Arc;
+//! use std::time::Instant;
 //! use dimpl::{Config, Dtls, certificate};
 //! use dimpl::crypto::aws_lc_rs;
 //!
@@ -53,7 +54,7 @@
 //! //         .unwrap()
 //! // );
 //!
-//! let dtls = Dtls::new(config, cert);
+//! let dtls = Dtls::new(config, cert, Instant::now());
 //! # }
 //! # #[cfg(not(all(feature = "aws-lc-rs", feature = "rcgen")))]
 //! # fn main() {}

--- a/src/crypto/rust_crypto/mod.rs
+++ b/src/crypto/rust_crypto/mod.rs
@@ -22,6 +22,7 @@
 //! # #[cfg(feature = "rcgen")]
 //! # fn main() {
 //! use std::sync::Arc;
+//! use std::time::Instant;
 //! use dimpl::{Config, Dtls, certificate};
 //! use dimpl::crypto::rust_crypto;
 //!
@@ -32,7 +33,7 @@
 //!         .build()
 //!         .unwrap()
 //! );
-//! let dtls = Dtls::new(config, cert);
+//! let dtls = Dtls::new(config, cert, Instant::now());
 //! # }
 //! # #[cfg(not(feature = "rcgen"))]
 //! # fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 //! fn mk_dtls_client() -> Dtls {
 //!     let cert = certificate::generate_self_signed_certificate().unwrap();
 //!     let cfg = Arc::new(Config::default());
-//!     let mut dtls = Dtls::new(cfg, cert);
+//!     let mut dtls = Dtls::new(cfg, cert, Instant::now());
 //!     dtls.set_active(true); // client role
 //!     dtls
 //! }
@@ -250,12 +250,14 @@ impl Dtls {
     /// Create a new DTLS instance.
     ///
     /// The instance is initialized with the provided `config` and `certificate`.
+    /// The `now` parameter seeds the internal time tracking for timeouts and
+    /// retransmissions.
     ///
     /// During the handshake, the peer's leaf certificate is surfaced via
     /// [`Output::PeerCert`]. It is up to the application to validate that
     /// certificate according to its security policy.
-    pub fn new(config: Arc<Config>, certificate: DtlsCertificate) -> Self {
-        let inner = Inner::Server(Server::new(config, certificate));
+    pub fn new(config: Arc<Config>, certificate: DtlsCertificate, now: Instant) -> Self {
+        let inner = Inner::Server(Server::new(config, certificate, now));
         Dtls { inner: Some(inner) }
     }
 
@@ -382,7 +384,7 @@ mod test {
         // Initialize client
         let config = Arc::new(Config::default());
 
-        Dtls::new(config, client_cert)
+        Dtls::new(config, client_cert, Instant::now())
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,7 +75,7 @@ pub struct Server {
     captured_session_hash: Option<Buf>,
 
     /// The last now we seen
-    last_now: Option<Instant>,
+    last_now: Instant,
 
     /// Events we are to emit from this Server.
     local_events: VecDeque<LocalEvent>,
@@ -105,12 +105,12 @@ enum State {
 
 impl Server {
     /// Create a new DTLS server
-    pub fn new(config: Arc<Config>, certificate: crate::DtlsCertificate) -> Server {
+    pub fn new(config: Arc<Config>, certificate: crate::DtlsCertificate, now: Instant) -> Server {
         let engine = Engine::new(config, certificate);
-        Self::new_with_engine(engine)
+        Self::new_with_engine(engine, now)
     }
 
-    pub(crate) fn new_with_engine(mut engine: Engine) -> Server {
+    pub(crate) fn new_with_engine(mut engine: Engine, now: Instant) -> Server {
         engine.set_client(false);
 
         let cookie_secret: [u8; 32] = engine.rng.random();
@@ -129,14 +129,14 @@ impl Server {
             client_certificates: Vec::with_capacity(3),
             defragment_buffer: Buf::new(),
             captured_session_hash: None,
-            last_now: None,
+            last_now: now,
             local_events: VecDeque::new(),
             queued_data: Vec::new(),
         }
     }
 
     pub fn into_client(self) -> Client {
-        Client::new_with_engine(self.engine)
+        Client::new_with_engine(self.engine, self.last_now)
     }
 
     pub(crate) fn state_name(&self) -> &'static str {
@@ -150,9 +150,7 @@ impl Server {
     }
 
     pub fn poll_output<'a>(&mut self, buf: &'a mut [u8]) -> Output<'a> {
-        let last_now = self
-            .last_now
-            .expect("need handle_timeout before poll_output");
+        let last_now = self.last_now;
 
         if let Some(event) = self.local_events.pop_front() {
             return event.into_output(buf, &self.client_certificates);
@@ -162,7 +160,7 @@ impl Server {
     }
 
     pub fn handle_timeout(&mut self, now: Instant) -> Result<(), Error> {
-        self.last_now = Some(now);
+        self.last_now = now;
         if self.random.is_none() {
             self.random = Some(Random::new(now, &mut self.engine.rng));
         }

--- a/tests/all-crypto.rs
+++ b/tests/all-crypto.rs
@@ -58,12 +58,15 @@ fn run_dimpl_client_vs_ossl_server_for_suite(suite: CipherSuite) {
         .private_key_to_der()
         .expect("client key der");
 
+    let now = Instant::now();
+
     let mut client = Dtls::new(
         config,
         dimpl::DtlsCertificate {
             certificate: client_x509_der,
             private_key: client_pkey_der,
         },
+        now,
     );
     client.set_active(true);
 
@@ -157,12 +160,15 @@ fn run_ossl_client_vs_dimpl_server_for_suite(suite: CipherSuite) {
         .private_key_to_der()
         .expect("server key der");
 
+    let now = Instant::now();
+
     let mut server = Dtls::new(
         config,
         dimpl::DtlsCertificate {
             certificate: server_x509_der,
             private_key: server_pkey_der,
         },
+        now,
     );
     server.set_active(false);
 

--- a/tests/client-fragments.rs
+++ b/tests/client-fragments.rs
@@ -44,12 +44,15 @@ fn run_client_server_with_mtu(mtu: usize) -> (usize, usize) {
         .private_key_to_der()
         .expect("Failed to get client private key DER");
 
+    let now = Instant::now();
+
     let mut client = Dtls::new(
         config,
         dimpl::DtlsCertificate {
             certificate: client_x509_der,
             private_key: client_pkey_der,
         },
+        now,
     );
     client.set_active(true);
 

--- a/tests/client-ossl.rs
+++ b/tests/client-ossl.rs
@@ -39,12 +39,15 @@ fn client_ossl() {
         .private_key_to_der()
         .expect("Failed to get client private key DER");
 
+    let now = Instant::now();
+
     let mut client = Dtls::new(
         config,
         dimpl::DtlsCertificate {
             certificate: client_x509_der,
             private_key: client_pkey_der,
         },
+        now,
     );
     client.set_active(true);
 

--- a/tests/cookie-retry.rs
+++ b/tests/cookie-retry.rs
@@ -69,10 +69,10 @@ fn cookie_retry_proceeds_to_server_hello() {
 
     let config = Arc::new(Config::builder().build().expect("Failed to build config"));
 
-    let mut client = Dtls::new(config.clone(), client_cert.clone());
+    let mut client = Dtls::new(config.clone(), client_cert.clone(), now);
     client.set_active(true);
 
-    let mut server = Dtls::new(config.clone(), server_cert.clone());
+    let mut server = Dtls::new(config.clone(), server_cert.clone(), now);
     server.set_active(false);
 
     // FLIGHT 1: Client sends ClientHello (no cookie)
@@ -188,9 +188,9 @@ fn parallel_handshakes_with_cookies() {
     // Create 5 parallel client-server pairs
     let mut pairs: Vec<(Dtls, Dtls)> = (0..5)
         .map(|_| {
-            let mut client = Dtls::new(config.clone(), client_cert.clone());
+            let mut client = Dtls::new(config.clone(), client_cert.clone(), now);
             client.set_active(true);
-            let mut server = Dtls::new(config.clone(), server_cert.clone());
+            let mut server = Dtls::new(config.clone(), server_cert.clone(), now);
             server.set_active(false);
             (client, server)
         })
@@ -267,10 +267,10 @@ fn retransmit_no_cookie_after_cookie_sent() {
 
     let config = Arc::new(Config::builder().build().expect("Failed to build config"));
 
-    let mut client = Dtls::new(config.clone(), client_cert.clone());
+    let mut client = Dtls::new(config.clone(), client_cert.clone(), now);
     client.set_active(true);
 
-    let mut server = Dtls::new(config.clone(), server_cert.clone());
+    let mut server = Dtls::new(config.clone(), server_cert.clone(), now);
     server.set_active(false);
 
     // Flight 1: ClientHello (no cookie)
@@ -360,10 +360,10 @@ fn retransmit_no_cookie_before_cookie_received() {
 
     let config = Arc::new(Config::builder().build().expect("Failed to build config"));
 
-    let mut client = Dtls::new(config.clone(), client_cert.clone());
+    let mut client = Dtls::new(config.clone(), client_cert.clone(), now);
     client.set_active(true);
 
-    let mut server = Dtls::new(config.clone(), server_cert.clone());
+    let mut server = Dtls::new(config.clone(), server_cert.clone(), now);
     server.set_active(false);
 
     // Flight 1: ClientHello (no cookie)

--- a/tests/resend-dupes.rs
+++ b/tests/resend-dupes.rs
@@ -105,11 +105,11 @@ fn duplicate_triggers_server_resend_of_final_flight() {
     );
 
     // Client
-    let mut client = Dtls::new(config_client, client_cert.clone());
+    let mut client = Dtls::new(config_client, client_cert.clone(), now);
     client.set_active(true);
 
     // Server
-    let mut server = Dtls::new(config_server, server_cert.clone());
+    let mut server = Dtls::new(config_server, server_cert.clone(), now);
     server.set_active(false);
 
     // FLIGHT 1 (ClientHello)

--- a/tests/resend-timers.rs
+++ b/tests/resend-timers.rs
@@ -94,11 +94,11 @@ fn resends_each_flight_epoch_and_sequence_increase() {
     let config_server = Arc::new(Config::default());
 
     // Client
-    let mut client = Dtls::new(config_client, client_cert.clone());
+    let mut client = Dtls::new(config_client, client_cert.clone(), now);
     client.set_active(true);
 
     // Server
-    let mut server = Dtls::new(config_server, server_cert.clone());
+    let mut server = Dtls::new(config_server, server_cert.clone(), now);
     server.set_active(false);
 
     // FLIGHT 1 (ClientHello): block initial, deliver resend

--- a/tests/server-ossl.rs
+++ b/tests/server-ossl.rs
@@ -37,12 +37,15 @@ fn server_ossl() {
         .private_key_to_der()
         .expect("Failed to get server private key DER");
 
+    let now = Instant::now();
+
     let mut server = Dtls::new(
         config,
         dimpl::DtlsCertificate {
             certificate: server_x509_der,
             private_key: server_pkey_der,
         },
+        now,
     );
     server.set_active(false);
 


### PR DESCRIPTION
## Summary
- Changed `last_now` from `Option<Instant>` to `Instant` in both `Client` and `Server`
- `Dtls::new()` now takes a `now: Instant` parameter, removing the requirement to call `handle_timeout` before `poll_output`
- Eliminates the panic (`"need handle_timeout before poll_output"`) that occurred if `poll_output` was called first

## Test plan
- [x] `cargo test` — all 65 tests pass (unit, integration, doctests)
- [x] `cargo test --features rust-crypto` — all 66 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)