### PR TITLE
feat: Add protocol_version() accessor to Dtls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,18 @@ impl Dtls {
         Dtls { inner: Some(inner) }
     }
 
+    /// Returns the negotiated DTLS protocol version.
+    ///
+    /// Returns `None` for auto-sense instances that have not yet completed
+    /// version negotiation (i.e. still in a `Pending` state).
+    pub fn protocol_version(&self) -> Option<ProtocolVersion> {
+        match self.inner.as_ref()? {
+            Inner::Client12(_) | Inner::Server12(_) => Some(ProtocolVersion::DTLS1_2),
+            Inner::Client13(_) | Inner::Server13(_) => Some(ProtocolVersion::DTLS1_3),
+            Inner::ServerPending(_) | Inner::ClientPending(_) => None,
+        }
+    }
+
     /// Return true if the instance is operating in the client role.
     pub fn is_active(&self) -> bool {
         matches!(
@@ -589,5 +601,24 @@ mod test {
         is_unwind_safe(new_instance());
         is_unwind_safe(new_instance_13());
         is_unwind_safe(new_instance_auto());
+    }
+
+    #[test]
+    fn test_protocol_version_12() {
+        let dtls = new_instance();
+        assert_eq!(dtls.protocol_version(), Some(ProtocolVersion::DTLS1_2));
+    }
+
+    #[test]
+    fn test_protocol_version_13() {
+        let dtls = new_instance_13();
+        assert_eq!(dtls.protocol_version(), Some(ProtocolVersion::DTLS1_3));
+    }
+
+    #[test]
+    fn test_protocol_version_auto_pending() {
+        let dtls = new_instance_auto();
+        // Auto-sense instance before negotiation should return None
+        assert_eq!(dtls.protocol_version(), None);
     }
 }

--- a/tests/auto/handshake.rs
+++ b/tests/auto/handshake.rs
@@ -598,3 +598,119 @@ fn auto_client_rejects_unknown_version_response() {
         other => panic!("expected UnexpectedMessage, got: {other:?}"),
     }
 }
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn auto_client_protocol_version_after_negotiating_dtls13() {
+    //! After completing a handshake against a DTLS 1.3 server, the
+    //! auto-sense client should report `Some(ProtocolVersion::DTLS1_3)`.
+    use dimpl::certificate::generate_self_signed_certificate;
+    use dimpl::ProtocolVersion;
+
+    let _ = env_logger::try_init();
+
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+
+    let config = default_config();
+    let mut now = Instant::now();
+
+    let mut client = Dtls::new_auto(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_13(config, server_cert, now);
+    server.set_active(false);
+
+    // Before negotiation, auto-sense returns None.
+    assert_eq!(client.protocol_version(), None);
+
+    let mut client_connected = false;
+    let mut server_connected = false;
+
+    for _ in 0..40 {
+        client.handle_timeout(now).expect("client timeout");
+        server.handle_timeout(now).expect("server timeout");
+
+        let client_out = drain_outputs(&mut client);
+        let server_out = drain_outputs(&mut server);
+
+        if client_out.connected {
+            client_connected = true;
+        }
+        if server_out.connected {
+            server_connected = true;
+        }
+
+        deliver_packets(&client_out.packets, &mut server);
+        deliver_packets(&server_out.packets, &mut client);
+
+        if client_connected && server_connected {
+            break;
+        }
+        now += Duration::from_millis(10);
+    }
+
+    assert!(
+        client_connected && server_connected,
+        "Handshake should complete"
+    );
+    assert_eq!(client.protocol_version(), Some(ProtocolVersion::DTLS1_3));
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn auto_client_protocol_version_after_negotiating_dtls12() {
+    //! After completing a handshake against a DTLS 1.2 server, the
+    //! auto-sense client should report `Some(ProtocolVersion::DTLS1_2)`.
+    use dimpl::certificate::generate_self_signed_certificate;
+    use dimpl::ProtocolVersion;
+
+    let _ = env_logger::try_init();
+
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+
+    let config = default_config();
+    let mut now = Instant::now();
+
+    let mut client = Dtls::new_auto(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_12(config, server_cert, now);
+    server.set_active(false);
+
+    // Before negotiation, auto-sense returns None.
+    assert_eq!(client.protocol_version(), None);
+
+    let mut client_connected = false;
+    let mut server_connected = false;
+
+    for _ in 0..40 {
+        client.handle_timeout(now).expect("client timeout");
+        server.handle_timeout(now).expect("server timeout");
+
+        let client_out = drain_outputs(&mut client);
+        let server_out = drain_outputs(&mut server);
+
+        if client_out.connected {
+            client_connected = true;
+        }
+        if server_out.connected {
+            server_connected = true;
+        }
+
+        deliver_packets(&client_out.packets, &mut server);
+        deliver_packets(&server_out.packets, &mut client);
+
+        if client_connected && server_connected {
+            break;
+        }
+        now += Duration::from_millis(10);
+    }
+
+    assert!(
+        client_connected && server_connected,
+        "Handshake should complete"
+    );
+    assert_eq!(client.protocol_version(), Some(ProtocolVersion::DTLS1_2));
+}


### PR DESCRIPTION
## Summary

Add a `protocol_version()` method to `Dtls` that returns the negotiated DTLS protocol version based on the current `Inner` variant.

- Returns `Some(ProtocolVersion::DTLS1_2)` for Client12/Server12
- Returns `Some(ProtocolVersion::DTLS1_3)` for Client13/Server13
- Returns `None` for Pending states (auto-sense before negotiation completes)

## Motivation

Downstream consumers using `Dtls::new_auto()` currently have no way to query which protocol version was negotiated after the handshake completes. The only workaround is parsing the `Debug` output for variant names like `"Client12"`, which is fragile and breaks on any formatting change.

Since the version is already implicit in the `Inner` enum, exposing it through a proper accessor is trivial and avoids coupling consumers to internal debug representations.