### PR TITLE
Add #[non_exhaustive] to public API enums likely to grow

### DIFF
--- a/src/crypto/keying.rs
+++ b/src/crypto/keying.rs
@@ -27,6 +27,7 @@ impl std::fmt::Debug for KeyingMaterial {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
+#[non_exhaustive]
 /// Supported SRTP protection profiles (RFC 5764).
 pub enum SrtpProfile {
     /// SRTP_AES128_CM_HMAC_SHA1_80 (RFC 5764)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Public error type returned by the high-level DTLS API.
 
 #[derive(Debug)]
+#[non_exhaustive]
 /// Errors returned by DTLS processing functions.
 pub enum Error {
     /// Parser requested more data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,6 +500,7 @@ impl fmt::Debug for Dtls {
 }
 
 /// Output events produced by the DTLS engine when polled.
+#[non_exhaustive]
 pub enum Output<'a> {
     /// A DTLS record to transmit on the wire.
     Packet(&'a [u8]),

--- a/src/types.rs
+++ b/src/types.rs
@@ -82,6 +82,7 @@ impl Random {
 /// Used for Elliptic Curve Diffie-Hellman Ephemeral (ECDHE) key exchange.
 /// The same named groups are used in both DTLS 1.2 and DTLS 1.3.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NamedGroup {
     /// sect163k1 (deprecated).
     Sect163k1,
@@ -536,6 +537,7 @@ impl PartialOrd for Sequence {
 /// separate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
+#[non_exhaustive]
 pub enum SignatureScheme {
     /// ECDSA with P-256 and SHA-256.
     ECDSA_SECP256R1_SHA256,
@@ -700,6 +702,7 @@ impl SignatureScheme {
 /// and hash function. Key exchange is negotiated separately via key_share.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
+#[non_exhaustive]
 pub enum Dtls13CipherSuite {
     /// TLS_AES_128_GCM_SHA256.
     AES_128_GCM_SHA256,

--- a/tests/auto/common.rs
+++ b/tests/auto/common.rs
@@ -49,6 +49,7 @@ pub fn drain_outputs(endpoint: &mut Dtls) -> DrainedOutputs {
                 result.timeout = Some(t);
                 break;
             }
+            _ => {}
         }
     }
     result

--- a/tests/dtls12/common.rs
+++ b/tests/dtls12/common.rs
@@ -134,6 +134,7 @@ pub fn drain_outputs(endpoint: &mut Dtls) -> DrainedOutputs {
                 result.timeout = Some(t);
                 break;
             }
+            _ => {}
         }
     }
     result

--- a/tests/dtls12/fragmentation.rs
+++ b/tests/dtls12/fragmentation.rs
@@ -114,6 +114,7 @@ fn run_client_server_with_mtu(mtu: usize) -> (usize, usize) {
                 Output::Timeout(_) => {
                     continue_polling = false;
                 }
+                _ => {}
             }
         }
 

--- a/tests/dtls12/ossl.rs
+++ b/tests/dtls12/ossl.rs
@@ -118,6 +118,7 @@ fn dtls12_ossl_client_handshake() {
                     // so we stop polling in this iteration
                     continue_polling = false;
                 }
+                _ => {}
             }
         }
 
@@ -315,6 +316,7 @@ fn dtls12_ossl_server_handshake() {
                     server_received_data.extend_from_slice(data);
                 }
                 Output::Timeout(_) => break,
+                _ => {}
             }
         }
 

--- a/tests/dtls13/common.rs
+++ b/tests/dtls13/common.rs
@@ -49,6 +49,7 @@ pub fn drain_outputs(endpoint: &mut Dtls) -> DrainedOutputs {
                 result.timeout = Some(t);
                 break;
             }
+            _ => {}
         }
     }
     result

--- a/tests/dtls13/handshake.rs
+++ b/tests/dtls13/handshake.rs
@@ -250,6 +250,7 @@ fn dtls13_srtp_keying_material_correct_size() {
         SrtpProfile::AEAD_AES_128_GCM => 2 * (16 + 12), // 2 * (key + salt) for AES-128-GCM
         SrtpProfile::AEAD_AES_256_GCM => 2 * (32 + 12), // 2 * (key + salt) for AES-256-GCM
         SrtpProfile::AES128_CM_SHA1_80 => 2 * (16 + 14), // 2 * (key + salt) for AES-128-CM
+        _ => unreachable!(),
     };
 
     assert_eq!(

--- a/tests/dtls13/wolfssl.rs
+++ b/tests/dtls13/wolfssl.rs
@@ -46,6 +46,7 @@ fn drain_dimpl_outputs(endpoint: &mut Dtls) -> DrainedOutputs {
                 result.timeout = Some(t);
                 break;
             }
+            _ => {}
         }
     }
 

--- a/tests/ossl/dtls.rs
+++ b/tests/ossl/dtls.rs
@@ -177,6 +177,7 @@ fn openssl_name(profile: &SrtpProfile) -> &'static str {
         SrtpProfile::AES128_CM_SHA1_80 => "SRTP_AES128_CM_SHA1_80",
         SrtpProfile::AEAD_AES_128_GCM => "SRTP_AEAD_AES_128_GCM",
         SrtpProfile::AEAD_AES_256_GCM => "SRTP_AEAD_AES_256_GCM",
+        _ => unreachable!(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `#[non_exhaustive]` to `Output`, `Error`, `SrtpProfile`, `NamedGroup`, `SignatureScheme`, and `Dtls13CipherSuite` so new variants can be added without a semver-breaking release
- Leave `HashAlgorithm`, `SignatureAlgorithm`, `ContentType`, `ProtocolVersion`, and `CompressionMethod` exhaustive — these are stable protocol-level types unlikely to gain new variants
- Add wildcard match arms in tests to satisfy the new requirement