### PR TITLE
Update package description to include DTLS 1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dimpl"
 authors = ["Martin Algesten <martin@algesten.se>"]
-description = "DTLS 1.2 implementation (Sans‑IO, Sync)"
+description = "DTLS 1.2/1.3 implementation (Sans‑IO, Sync)"
 version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The crate now supports DTLS 1.3, but the Cargo.toml description still only mentioned DTLS 1.2. This PR updates it to reflect the current state.