### PR TITLE
fix: bump rand 0.9.2 -> 0.9.3 (RUSTSEC-2026-0097)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,9 +1142,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary
- Bumps `rand` from 0.9.2 to 0.9.3 to address security advisory RUSTSEC-2026-0097
- Lockfile-only change — `Cargo.toml` already specifies `rand = "0.9"` which covers 0.9.3
- Compatible with MSRV 1.85.0 (confirmed by `cargo update` resolver)

## Test plan
- [x] `cargo test` — all 95 tests + 8 doc-tests pass