### PR TITLE
fix: reject empty certificate at DTLS 1.2 construction

### DIFF
--- a/src/dtls12/client.rs
+++ b/src/dtls12/client.rs
@@ -128,6 +128,10 @@ impl Client {
         certificate: DtlsCertificate,
         now: Instant,
     ) -> Result<Client, Error> {
+        assert!(
+            !certificate.certificate.is_empty(),
+            "Client certificate cannot be empty"
+        );
         // unwrap: malformed private_key bytes are a programmer error from the
         // caller who constructed DtlsCertificate; panic matches the prior
         // CryptoContext::new behavior which also panicked on empty/invalid

--- a/src/dtls12/server.rs
+++ b/src/dtls12/server.rs
@@ -126,6 +126,10 @@ enum State {
 impl Server {
     /// Create a new DTLS server
     pub fn new(config: Arc<Config>, certificate: crate::DtlsCertificate, now: Instant) -> Server {
+        assert!(
+            !certificate.certificate.is_empty(),
+            "Server certificate cannot be empty"
+        );
         // unwrap: malformed private_key bytes are a programmer error from the
         // caller who constructed DtlsCertificate; panic matches the prior
         // CryptoContext::new behavior which also panicked on empty/invalid

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -877,6 +877,18 @@ mod test {
     }
 
     #[test]
+    #[should_panic(expected = "Server certificate cannot be empty")]
+    fn new_12_panics_on_empty_certificate() {
+        let cert = generate_self_signed_certificate().expect("Failed to generate cert");
+        let config = Arc::new(Config::default());
+        let empty = DtlsCertificate {
+            certificate: vec![],
+            private_key: cert.private_key,
+        };
+        let _ = Dtls::new_12(config, empty, Instant::now());
+    }
+
+    #[test]
     fn test_auto_server_send_application_data_pending() {
         let mut dtls = new_instance_auto();
         let err = dtls.send_application_data(b"early data").unwrap_err();


### PR DESCRIPTION
## Summary
- `Server::new` and `Client::new_from_hybrid` now panic on empty certificate, restoring the pre-refactor `CryptoContext::new` fail-fast behaviour.
- Adds a `#[should_panic]` regression test for `Dtls::new_12` with an empty certificate.

Fixes #101.

## Test plan
- [x] `cargo test --all-features` (full suite green, including new `new_12_panics_on_empty_certificate`)