### PR TITLE
Change return value of close to bool to indicate if the close packet …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/src/dtls12/client.rs
+++ b/src/dtls12/client.rs
@@ -235,14 +235,14 @@ impl Client {
     }
 
     /// Initiate graceful shutdown by sending a `close_notify` alert.
-    pub fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<bool, Error> {
         if self.state == State::Closed {
-            return Ok(());
+            return Ok(false);
         }
         if self.state != State::AwaitApplicationData {
             self.engine.abort();
             self.state = State::Closed;
-            return Ok(());
+            return Ok(false);
         }
         self.engine
             .create_record(ContentType::Alert, 1, false, |body| {
@@ -250,7 +250,7 @@ impl Client {
                 body.push(0); // description: close_notify
             })?;
         self.state = State::Closed;
-        Ok(())
+        Ok(true)
     }
 
     fn make_progress(&mut self) -> Result<(), Error> {

--- a/src/dtls12/server.rs
+++ b/src/dtls12/server.rs
@@ -232,14 +232,14 @@ impl Server {
     }
 
     /// Initiate graceful shutdown by sending a `close_notify` alert.
-    pub fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<bool, Error> {
         if self.state == State::Closed {
-            return Ok(());
+            return Ok(false);
         }
         if self.state != State::AwaitApplicationData {
             self.engine.abort();
             self.state = State::Closed;
-            return Ok(());
+            return Ok(false);
         }
         self.engine
             .create_record(ContentType::Alert, 1, false, |body| {
@@ -247,7 +247,7 @@ impl Server {
                 body.push(0); // description: close_notify
             })?;
         self.state = State::Closed;
-        Ok(())
+        Ok(true)
     }
 
     fn make_progress(&mut self) -> Result<(), Error> {

--- a/src/dtls13/client.rs
+++ b/src/dtls13/client.rs
@@ -271,14 +271,14 @@ impl Client {
     }
 
     /// Initiate graceful shutdown by sending a `close_notify` alert.
-    pub fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<bool, Error> {
         if self.state == State::Closed || self.state == State::HalfClosedLocal {
-            return Ok(());
+            return Ok(false);
         }
         if self.state != State::AwaitApplicationData {
             self.engine.abort();
             self.state = State::Closed;
-            return Ok(());
+            return Ok(false);
         }
         let epoch = self.engine.app_send_epoch();
         self.engine
@@ -288,7 +288,7 @@ impl Client {
             })?;
         self.engine.cancel_flights();
         self.state = State::HalfClosedLocal;
-        Ok(())
+        Ok(true)
     }
 
     fn make_progress(&mut self) -> Result<(), Error> {

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -307,14 +307,14 @@ impl Server {
     }
 
     /// Initiate graceful shutdown by sending a `close_notify` alert.
-    pub fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<bool, Error> {
         if self.state == State::Closed || self.state == State::HalfClosedLocal {
-            return Ok(());
+            return Ok(false);
         }
         if self.state != State::AwaitApplicationData {
             self.engine.abort();
             self.state = State::Closed;
-            return Ok(());
+            return Ok(false);
         }
         let epoch = self.engine.app_send_epoch();
         self.engine
@@ -324,7 +324,7 @@ impl Server {
             })?;
         self.engine.cancel_flights();
         self.state = State::HalfClosedLocal;
-        Ok(())
+        Ok(true)
     }
 
     fn make_progress(&mut self) -> Result<(), Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,7 +790,7 @@ impl Dtls {
     /// connection can simply drop the [`Dtls`] value.
     ///
     /// The alert is not retransmitted (per RFC 6347 §4.2.7 / RFC 9147 §5.10).
-    pub fn close(&mut self) -> Result<(), Error> {
+    pub fn close(&mut self) -> Result<bool, Error> {
         let inner = self.inner.as_mut().unwrap();
 
         if inner.is_pending() {


### PR DESCRIPTION
…was queued up

In preparation for

https://github.com/algesten/str0m/issues/949

The return value will be propagated to the application (from a new `close` method on `Rtc`) and the application will know if it needs to poll for output or can just drop the Rtc instance.
