### PR TITLE
tests: satisfy clippy warnings

### DIFF
--- a/src/crypto/prf_hkdf.rs
+++ b/src/crypto/prf_hkdf.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
 
     fn hex_to_vec(hex: &str) -> Vec<u8> {
-        let hex = hex.replace(' ', "").replace('\n', "");
+        let hex = hex.replace([' ', '\n'], "");
         let mut v = Vec::new();
         for i in 0..hex.len() / 2 {
             // unwrap: test-only hex parsing

--- a/tests/dtls12/ossl.rs
+++ b/tests/dtls12/ossl.rs
@@ -797,14 +797,12 @@ fn dtls12_ossl_server_bidirectional_data() {
                 Output::Connected => {
                     server_connected = true;
                 }
-                Output::KeyingMaterial(_km, _profile) => {
+                Output::KeyingMaterial(_km, _profile) if !server_first_sent => {
                     // Server handshake complete -- send first message
-                    if !server_first_sent {
-                        server
-                            .send_application_data(server_test_data)
-                            .expect("Server failed to send app data");
-                        server_first_sent = true;
-                    }
+                    server
+                        .send_application_data(server_test_data)
+                        .expect("Server failed to send app data");
+                    server_first_sent = true;
                 }
                 Output::ApplicationData(data) => {
                     server_received_data.extend_from_slice(data);


### PR DESCRIPTION
## Summary

This is a small mechanical cleanup so `cargo clippy --all-targets --features rcgen -- -D warnings` passes on current `main`.

- Collapse consecutive string replacements in the HKDF test helper into one call.
- Simplify the OpenSSL DTLS 1.2 bidirectional-data test match arm to satisfy the collapsible-match lint.

There is no intended behavior change.

## Validation

- `cargo fmt --check`
- `git diff --check upstream/main..HEAD`
- `cargo clippy --all-targets --features rcgen -- -D warnings`
- `cargo test --test dtls12 --features rcgen dtls12_ossl_server_bidirectional_data`
