### PR TITLE
dtls: reject malformed signature_algorithms vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Reject malformed DTLS signature_algorithms vectors #111
+
 # 0.6.1
 
   * Fix auto-sense server falling back to DTLS 1.2 on non-ClientHello parse errors #106

--- a/src/dtls12/message/extensions/signature_algorithms.rs
+++ b/src/dtls12/message/extensions/signature_algorithms.rs
@@ -1,6 +1,9 @@
 use super::super::{SignatureAndHashAlgorithm, SignatureAndHashAlgorithmVec};
 use crate::buffer::Buf;
+use nom::Err;
 use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 
 /// SignatureAlgorithms extension as defined in RFC 5246
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,23 +23,30 @@ impl SignatureAlgorithmsExtension {
 
     pub fn parse(input: &[u8]) -> IResult<&[u8], SignatureAlgorithmsExtension> {
         let (input, list_len) = nom::number::complete::be_u16(input)?;
+        if list_len == 0 || list_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         let mut algorithms = SignatureAndHashAlgorithmVec::new();
-        let mut remaining = list_len as usize;
-        let mut current_input = input;
+        let (input, mut current_input) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
         // Parse algorithms, filtering to only keep supported ones
-        while remaining > 0 {
+        while !current_input.is_empty() {
             let (rest, alg) = SignatureAndHashAlgorithm::parse(current_input)?;
             // Only keep supported signature+hash combinations
             if alg.is_supported() {
-                algorithms.push(alg);
+                algorithms
+                    .try_push(alg)
+                    .map_err(|_| Err::Failure(Error::new(current_input, ErrorKind::LengthValue)))?;
             }
             current_input = rest;
-            remaining -= 2; // Each algorithm pair is 2 bytes
         }
 
         Ok((
-            current_input,
+            input,
             SignatureAlgorithmsExtension {
                 supported_signature_algorithms: algorithms,
             },
@@ -92,5 +102,86 @@ mod tests {
         let (_, parsed) = SignatureAlgorithmsExtension::parse(&serialized).unwrap();
 
         assert_eq!(parsed.supported_signature_algorithms, algorithms);
+    }
+
+    #[test]
+    fn too_many_supported_signature_algorithms_are_rejected() {
+        let mut bytes = Vec::new();
+        let count = SignatureAndHashAlgorithm::supported().len() + 1;
+        bytes.extend_from_slice(&(count as u16 * 2).to_be_bytes());
+        for _ in 0..count {
+            bytes.extend_from_slice(
+                &SignatureAndHashAlgorithm::new(HashAlgorithm::SHA256, SignatureAlgorithm::ECDSA)
+                    .as_u16()
+                    .to_be_bytes(),
+            );
+        }
+
+        let result = SignatureAlgorithmsExtension::parse(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many supported signature algorithms should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn odd_length_signature_algorithms_are_rejected_without_panic() {
+        let result = std::panic::catch_unwind(|| {
+            SignatureAlgorithmsExtension::parse(&[
+                0x00, 0x01, // Declared list length is not divisible by 2.
+                0x04, 0x03, // Extra byte proves the parser must reject before looping.
+            ])
+        });
+
+        assert!(
+            result.is_ok(),
+            "odd signature_algorithms length must not panic"
+        );
+        assert!(
+            matches!(
+                result.unwrap(),
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "odd signature_algorithms length should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn empty_signature_algorithms_are_rejected() {
+        let result = SignatureAlgorithmsExtension::parse(&[
+            0x00, 0x00, // Empty signature_algorithms vector is invalid.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "empty signature_algorithms vector should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_signature_algorithms_bytes_are_rejected() {
+        let result = SignatureAlgorithmsExtension::parse(&[
+            0x00, 0x02, // One algorithm follows.
+            0x04, 0x03, // SHA256/ECDSA
+            0xff, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing signature_algorithms bytes should fail with LengthValue"
+        );
     }
 }

--- a/src/dtls13/message/extensions/signature_algorithms.rs
+++ b/src/dtls13/message/extensions/signature_algorithms.rs
@@ -1,7 +1,10 @@
 use crate::buffer::Buf;
 use crate::types::SignatureScheme;
 use arrayvec::ArrayVec;
+use nom::Err;
 use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 
 /// SignatureAlgorithms extension for TLS 1.3 (RFC 8446 Section 4.2.3).
 ///
@@ -21,21 +24,28 @@ impl SignatureAlgorithmsExtension {
 
     pub fn parse(input: &[u8]) -> IResult<&[u8], SignatureAlgorithmsExtension> {
         let (input, list_len) = nom::number::complete::be_u16(input)?;
-        let mut algorithms: ArrayVec<SignatureScheme, 2> = ArrayVec::new();
-        let mut remaining = list_len as usize;
-        let mut current_input = input;
+        if list_len == 0 || list_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
-        while remaining > 0 {
+        let mut algorithms: ArrayVec<SignatureScheme, 2> = ArrayVec::new();
+        let (input, mut current_input) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
+        while !current_input.is_empty() {
             let (rest, scheme) = SignatureScheme::parse(current_input)?;
             if scheme.is_supported() {
-                algorithms.push(scheme);
+                algorithms
+                    .try_push(scheme)
+                    .map_err(|_| Err::Failure(Error::new(current_input, ErrorKind::LengthValue)))?;
             }
             current_input = rest;
-            remaining -= 2;
         }
 
         Ok((
-            current_input,
+            input,
             SignatureAlgorithmsExtension {
                 supported_signature_algorithms: algorithms,
             },
@@ -90,6 +100,88 @@ mod tests {
             ext.supported_signature_algorithms.capacity(),
             SignatureScheme::supported().len(),
             "SignatureAlgorithmsExtension capacity must match supported schemes count"
+        );
+    }
+
+    #[test]
+    fn too_many_supported_signature_algorithms_are_rejected() {
+        let mut bytes = Vec::new();
+        let supported = SignatureScheme::supported();
+        let count = supported.len() + 1;
+        bytes.extend_from_slice(&(count as u16 * 2).to_be_bytes());
+        for _ in 0..count {
+            bytes.extend_from_slice(
+                &SignatureScheme::ECDSA_SECP256R1_SHA256
+                    .as_u16()
+                    .to_be_bytes(),
+            );
+        }
+
+        let result = SignatureAlgorithmsExtension::parse(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many supported signature algorithms should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn odd_length_signature_algorithms_are_rejected_without_panic() {
+        let result = std::panic::catch_unwind(|| {
+            SignatureAlgorithmsExtension::parse(&[
+                0x00, 0x01, // Declared list length is not divisible by 2.
+                0x04, 0x03, // Extra byte proves the parser must reject before looping.
+            ])
+        });
+
+        assert!(
+            result.is_ok(),
+            "odd signature_algorithms length must not panic"
+        );
+        assert!(
+            matches!(
+                result.unwrap(),
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "odd signature_algorithms length should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn empty_signature_algorithms_are_rejected() {
+        let result = SignatureAlgorithmsExtension::parse(&[
+            0x00, 0x00, // Empty signature_algorithms vector is invalid.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "empty signature_algorithms vector should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_signature_algorithms_bytes_are_rejected() {
+        let result = SignatureAlgorithmsExtension::parse(&[
+            0x00, 0x02, // One algorithm follows.
+            0x04, 0x03, // ECDSA_SECP256R1_SHA256
+            0xff, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing signature_algorithms bytes should fail with LengthValue"
         );
     }
 }


### PR DESCRIPTION
## Summary

Reject malformed signature_algorithms extension bodies on both DTLS 1.2 and DTLS 1.3 parser paths.

Before this patch, odd vector lengths could underflow parser loop accounting in debug/overflow-checking builds, empty vectors were accepted, trailing extension-body bytes were left unconsumed, and supported entries beyond the fixed output vector capacity could panic.

This patch rejects empty or odd-length vectors, parses only the declared vector, rejects trailing extension-body bytes, converts supported-entry pushes to fallible try_push, and adds DTLS 1.2 and DTLS 1.3 parser regressions.

## Validation

- `cargo fmt --check`
- `cargo test signature_algorithms --features rcgen`
- `cargo test --all-targets --features rcgen`
- `cargo clippy --lib --features rcgen -- -D warnings`
- `git diff --check`
