### PR TITLE
dtls12: discard short encrypted records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+  * Discard short DTLS 1.2 encrypted records #112
+
 # 0.6.1
 
   * Fix auto-sense server falling back to DTLS 1.2 on non-ClientHello parse errors #106

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-  * Discard short DTLS 1.2 encrypted records #112
+  * Discard short DTLS 1.2 and 1.3 encrypted records #112
 
 # 0.6.1
 

--- a/src/crypto/provider.rs
+++ b/src/crypto/provider.rs
@@ -254,6 +254,16 @@ pub trait SupportedDtls12CipherSuite: CryptoSafe {
     /// AEAD authentication tag length in bytes.
     fn tag_len(&self) -> usize;
 
+    /// Minimum length, in bytes, of a protected record's encrypted fragment.
+    ///
+    /// For AEAD suites this equals explicit nonce + authentication tag; a CBC
+    /// suite would override this to `IV + MAC + 1` (one padding byte). Records
+    /// shorter than this cannot be valid regardless of cipher mode and are
+    /// rejected at the record boundary.
+    fn min_protected_fragment_len(&self) -> usize {
+        self.explicit_nonce_len() + self.tag_len()
+    }
+
     /// Create a cipher instance with the given key.
     fn create_cipher(&self, key: &[u8]) -> Result<Box<dyn Cipher>, String>;
 }
@@ -426,6 +436,14 @@ pub trait SupportedDtls13CipherSuite: CryptoSafe {
 
     /// AEAD tag length in bytes.
     fn tag_len(&self) -> usize;
+
+    /// Minimum length, in bytes, of a protected record's encrypted fragment.
+    /// DTLS 1.3 has no explicit nonce in the record, so this equals
+    /// [`Self::tag_len`]. Records shorter than this cannot hold a valid
+    /// ciphertext + tag and are rejected at the record boundary.
+    fn min_protected_fragment_len(&self) -> usize {
+        self.tag_len()
+    }
 
     /// Create a cipher instance with the given key.
     fn create_cipher(&self, key: &[u8]) -> Result<Box<dyn Cipher>, String>;

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -1212,6 +1212,10 @@ impl RecordHandler for Engine {
         self.explicit_nonce_len
     }
 
+    fn aead_overhead(&self) -> usize {
+        Engine::aead_overhead(self)
+    }
+
     fn decrypt_data(
         &mut self,
         ciphertext: &mut TmpBuf,

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -45,11 +45,16 @@ pub struct Engine {
     /// The cipher suite in use. Set by ServerHello.
     cipher_suite: Option<Dtls12CipherSuite>,
 
-    /// Per-record explicit nonce length (from provider). 0 for ChaCha20, 8 for AES-GCM.
+    /// Per-record explicit nonce length, cached from the provider suite at
+    /// `set_cipher_suite` time. 0 for ChaCha20-Poly1305, 8 for AES-GCM.
     explicit_nonce_len: usize,
 
-    /// AEAD tag length (from provider).
-    tag_len: usize,
+    /// Minimum length of a protected record's encrypted fragment, cached from
+    /// the provider suite. See
+    /// [`crate::crypto::SupportedDtls12CipherSuite::min_protected_fragment_len`].
+    /// For AEAD suites this is `explicit_nonce + tag`; used both to reject
+    /// short incoming records and to size outgoing record overhead.
+    min_protected_fragment_len: usize,
 
     /// Cryptographic context for handling encryption/decryption
     pub(crate) crypto_context: CryptoContext,
@@ -129,7 +134,7 @@ impl Engine {
             queue_tx: QueueTx::new(),
             cipher_suite: None,
             explicit_nonce_len: 0,
-            tag_len: 0,
+            min_protected_fragment_len: 0,
             crypto_context,
             peer_encryption_enabled: false,
             is_client: false,
@@ -176,9 +181,11 @@ impl Engine {
         self.cipher_suite
     }
 
-    /// Total per-record AEAD overhead: explicit_nonce_len + tag_len.
-    pub fn aead_overhead(&self) -> usize {
-        self.explicit_nonce_len + self.tag_len
+    /// Minimum length of a protected record's encrypted fragment for the
+    /// negotiated suite. See
+    /// [`crate::crypto::SupportedDtls12CipherSuite::min_protected_fragment_len`].
+    pub fn min_protected_fragment_len(&self) -> usize {
+        self.min_protected_fragment_len
     }
 
     /// Is the given cipher suite allowed by configuration
@@ -660,10 +667,12 @@ impl Engine {
             });
         }
 
-        // Compute wire length of the record if serialized into a datagram
-        // Record header (13) + handshake/change/app data bytes + AEAD overhead (if epoch >= 1)
+        // Compute wire length of the record if serialized into a datagram.
+        // Record header (13) + handshake/change/app data bytes + per-suite
+        // protection overhead (if epoch >= 1). For AEAD suites the protection
+        // overhead equals the min-protected-fragment-len.
         let overhead = if maybe_suite.is_some() {
-            self.aead_overhead()
+            self.min_protected_fragment_len()
         } else {
             0
         };
@@ -823,10 +832,12 @@ impl Engine {
 
         // Handshake header is 12 bytes
         let handshake_header_len = 12usize;
-        let aead_overhead = if epoch >= 1 {
+        // Per-record protection overhead on the wire (for AEAD suites this is
+        // explicit_nonce + tag). Used to size fragments to fit the MTU.
+        let protection_overhead = if epoch >= 1 {
             self.cipher_suite()
                 .ok_or_else(|| Error::UnexpectedMessage("No cipher suite selected".to_string()))?;
-            self.aead_overhead()
+            self.min_protected_fragment_len()
         } else {
             0
         };
@@ -838,8 +849,9 @@ impl Engine {
             let available_in_current = self.config.mtu().saturating_sub(already_used_in_current);
 
             // Fixed overhead per handshake record on the wire:
-            // DTLS record header + handshake header + AEAD overhead (if epoch >= 1)
-            let fixed_overhead = DTLSRecord::HEADER_LEN + handshake_header_len + aead_overhead;
+            // DTLS record header + handshake header + protection overhead (if epoch >= 1)
+            let fixed_overhead =
+                DTLSRecord::HEADER_LEN + handshake_header_len + protection_overhead;
 
             // Prefer to pack into the current datagram. If the current one cannot fit even
             // the fixed overhead, we will start a fresh datagram and compute space again.
@@ -1016,7 +1028,9 @@ impl Engine {
     }
 
     pub fn set_cipher_suite(&mut self, cipher_suite: Dtls12CipherSuite) {
-        // Look up AEAD record parameters from the provider (single source of truth)
+        // Cache AEAD record parameters from the provider suite. The formula
+        // (explicit_nonce + tag) lives on the suite trait; Engine just stores
+        // the resolved values for hot-path access.
         let provider_suite = self
             .crypto_context
             .provider()
@@ -1025,7 +1039,7 @@ impl Engine {
             .find(|cs| cs.suite() == cipher_suite)
             .expect("cipher suite must be in provider");
         self.explicit_nonce_len = provider_suite.explicit_nonce_len();
-        self.tag_len = provider_suite.tag_len();
+        self.min_protected_fragment_len = provider_suite.min_protected_fragment_len();
         self.cipher_suite = Some(cipher_suite);
     }
 
@@ -1073,7 +1087,9 @@ impl Engine {
     pub fn decryption_aad_and_nonce(&self, dtls: &DTLSRecord, buf: &[u8]) -> (Aad, Nonce) {
         // DTLS 1.2 AEAD: AAD uses the plaintext length. Recover plaintext length
         // from the record header by subtracting this suite's wire overhead.
-        let plaintext_len = dtls.length.saturating_sub(self.aead_overhead() as u16);
+        let plaintext_len = dtls
+            .length
+            .saturating_sub(self.min_protected_fragment_len() as u16);
         let aad = Aad::new_dtls12(dtls.content_type, dtls.sequence, plaintext_len);
         let iv = self.peer_iv();
         let seq64 = ((dtls.sequence.epoch as u64) << 48) | dtls.sequence.sequence_number;
@@ -1212,8 +1228,8 @@ impl RecordHandler for Engine {
         self.explicit_nonce_len
     }
 
-    fn aead_overhead(&self) -> usize {
-        Engine::aead_overhead(self)
+    fn min_protected_fragment_len(&self) -> usize {
+        self.min_protected_fragment_len
     }
 
     fn decrypt_data(

--- a/src/dtls12/incoming.rs
+++ b/src/dtls12/incoming.rs
@@ -175,7 +175,7 @@ impl Record {
         }
 
         let explicit_nonce_len = decrypt.explicit_nonce_len();
-        if (dtls.length as usize) < decrypt.aead_overhead() {
+        if (dtls.length as usize) < decrypt.min_protected_fragment_len() {
             return Ok(None);
         }
 
@@ -296,7 +296,7 @@ pub trait RecordHandler {
     fn replay_update(&mut self, seq: Sequence);
     fn decryption_aad_and_nonce(&self, dtls: &DTLSRecord, buf: &[u8]) -> (Aad, Nonce);
     fn explicit_nonce_len(&self) -> usize;
-    fn aead_overhead(&self) -> usize;
+    fn min_protected_fragment_len(&self) -> usize;
     fn decrypt_data(
         &mut self,
         ciphertext: &mut TmpBuf,
@@ -415,8 +415,8 @@ mod tests {
             panic!("explicit_nonce_len should not be called for plaintext tests");
         }
 
-        fn aead_overhead(&self) -> usize {
-            panic!("aead_overhead should not be called for plaintext tests");
+        fn min_protected_fragment_len(&self) -> usize {
+            panic!("min_protected_fragment_len should not be called for plaintext tests");
         }
 
         fn decrypt_data(

--- a/src/dtls12/incoming.rs
+++ b/src/dtls12/incoming.rs
@@ -174,12 +174,16 @@ impl Record {
             return Ok(None);
         }
 
+        let explicit_nonce_len = decrypt.explicit_nonce_len();
+        if (dtls.length as usize) < decrypt.aead_overhead() {
+            return Ok(None);
+        }
+
         // Get a reference to the buffer
         let (aad, nonce) = decrypt.decryption_aad_and_nonce(dtls, &record.buffer);
 
         // Extract the buffer for decryption
         let mut buffer = record.buffer;
-        let explicit_nonce_len = decrypt.explicit_nonce_len();
 
         // Local shorthand for where the encrypted ciphertext starts
         let ciph = DTLSRecord::HEADER_LEN + explicit_nonce_len;
@@ -292,6 +296,7 @@ pub trait RecordHandler {
     fn replay_update(&mut self, seq: Sequence);
     fn decryption_aad_and_nonce(&self, dtls: &DTLSRecord, buf: &[u8]) -> (Aad, Nonce);
     fn explicit_nonce_len(&self) -> usize;
+    fn aead_overhead(&self) -> usize;
     fn decrypt_data(
         &mut self,
         ciphertext: &mut TmpBuf,
@@ -408,6 +413,10 @@ mod tests {
 
         fn explicit_nonce_len(&self) -> usize {
             panic!("explicit_nonce_len should not be called for plaintext tests");
+        }
+
+        fn aead_overhead(&self) -> usize {
+            panic!("aead_overhead should not be called for plaintext tests");
         }
 
         fn decrypt_data(

--- a/src/dtls13/engine.rs
+++ b/src/dtls13/engine.rs
@@ -1142,7 +1142,9 @@ impl Engine {
         } else {
             0
         };
-        let aead_overhead = if epoch >= 2 { tag_len + 1 } else { 0 }; // +1 for inner content type
+        // Per-record protection overhead on the wire: tag + 1 byte inner
+        // content type (the DTLS 1.3 record protection layer's expansion).
+        let protection_overhead = if epoch >= 2 { tag_len + 1 } else { 0 };
 
         while offset < total_len || (total_len == 0 && offset == 0) {
             let already_used_in_current = self.queue_tx.back().map(|b| b.len()).unwrap_or(0);
@@ -1154,7 +1156,7 @@ impl Engine {
                 5 // unified header: flags(1) + seq(2) + length(2)
             };
 
-            let fixed_overhead = record_header_len + handshake_header_len + aead_overhead;
+            let fixed_overhead = record_header_len + handshake_header_len + protection_overhead;
 
             let available_for_body = if available_in_current > fixed_overhead {
                 available_in_current - fixed_overhead
@@ -2387,6 +2389,10 @@ impl RecordHandler for Engine {
                 }
             }
         }
+    }
+
+    fn min_protected_fragment_len(&self) -> usize {
+        self.suite_provider().min_protected_fragment_len()
     }
 
     fn decrypt_record(

--- a/src/dtls13/incoming.rs
+++ b/src/dtls13/incoming.rs
@@ -251,6 +251,14 @@ impl Record {
         // Save the raw header bytes for AAD before mutating the buffer.
         // Max unified header without CID: flags(1) + seq(2) + length(2) = 5 bytes.
         let header_end = record.record().fragment_range.start;
+
+        // Reject protected records whose encrypted fragment is shorter than
+        // the per-suite minimum — they cannot hold a valid ciphertext + tag,
+        // so decryption would necessarily fail. Catching it here keeps the
+        // cipher impls' bounds-checking from being the only line of defence.
+        if record.buffer.len() - header_end < decrypt.min_protected_fragment_len() {
+            return Ok(None);
+        }
         let mut header_buf = [0u8; 5];
         header_buf[..header_end].copy_from_slice(&record.buffer[..header_end]);
 
@@ -402,6 +410,12 @@ pub trait RecordHandler {
     fn resolve_sequence(&self, epoch: u16, seq_bits: u64, s_flag: bool) -> u64;
     fn replay_check(&self, seq: Sequence) -> bool;
     fn replay_update(&mut self, seq: Sequence);
+
+    /// Minimum length of a protected record's encrypted fragment for the
+    /// negotiated suite (tag length in DTLS 1.3). Used to reject records that
+    /// cannot possibly contain a valid ciphertext + tag.
+    fn min_protected_fragment_len(&self) -> usize;
+
     fn decrypt_record(
         &mut self,
         header: &[u8],
@@ -552,6 +566,12 @@ mod tests {
 
         fn replay_update(&mut self, _seq: Sequence) {
             panic!("replay_update should not be called when peer encryption is disabled");
+        }
+
+        fn min_protected_fragment_len(&self) -> usize {
+            panic!(
+                "min_protected_fragment_len should not be called when peer encryption is disabled"
+            );
         }
 
         fn decrypt_record(

--- a/tests/dtls12/edge.rs
+++ b/tests/dtls12/edge.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "rcgen")]
 use dimpl::certificate::generate_self_signed_certificate;
-use dimpl::{Dtls, Output};
+use dimpl::crypto::Dtls12CipherSuite;
+use dimpl::{Config, Dtls, Output};
 
 use crate::common::*;
 
@@ -18,6 +19,47 @@ fn dtls12_alert_record(seq: u64, level: u8, description: u8) -> Vec<u8> {
     out.extend_from_slice(&2u16.to_be_bytes()); // alert payload length
     out.extend_from_slice(&[level, description]);
     out
+}
+
+fn dtls12_epoch1_record(seq: u64, len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(13 + len);
+    out.push(23); // ApplicationData
+    out.extend_from_slice(&[0xFE, 0xFD]); // DTLS 1.2
+    out.extend_from_slice(&1u16.to_be_bytes()); // epoch 1
+    out.extend_from_slice(&seq.to_be_bytes()[2..]); // u48 sequence number
+    out.extend_from_slice(&(len as u16).to_be_bytes());
+    out.resize(13 + len, 0);
+    out
+}
+
+fn dtls12_config_for_suite(suite: Dtls12CipherSuite) -> Arc<Config> {
+    let mut provider = Config::default().crypto_provider().clone();
+    let selected = provider
+        .cipher_suites
+        .iter()
+        .copied()
+        .find(|cs| cs.suite() == suite)
+        .unwrap_or_else(|| panic!("suite {:?} not found in provider", suite));
+
+    let suites = Box::leak(Box::new([selected]));
+    provider.cipher_suites = suites;
+
+    Arc::new(
+        Config::builder()
+            .with_crypto_provider(provider)
+            .build()
+            .expect("build config for single suite"),
+    )
+}
+
+fn dtls12_aead_overhead(suite: Dtls12CipherSuite) -> usize {
+    match suite {
+        Dtls12CipherSuite::ECDHE_ECDSA_AES256_GCM_SHA384
+        | Dtls12CipherSuite::ECDHE_ECDSA_AES128_GCM_SHA256 => 24,
+        Dtls12CipherSuite::ECDHE_ECDSA_CHACHA20_POLY1305_SHA256 => 16,
+        Dtls12CipherSuite::PSK_AES128_CCM_8 => 16,
+        Dtls12CipherSuite::Unknown(_) => panic!("unknown cipher suite"),
+    }
 }
 
 #[test]
@@ -230,6 +272,55 @@ fn dtls12_discards_wrong_epoch_record() {
         server_out.app_data.iter().any(|d| d.as_slice() == b"ping"),
         "Server should receive application data after wrong-epoch bogus packet"
     );
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_short_encrypted_records_do_not_panic() {
+    let _ = env_logger::try_init();
+
+    for suite in [
+        Dtls12CipherSuite::ECDHE_ECDSA_AES128_GCM_SHA256,
+        Dtls12CipherSuite::ECDHE_ECDSA_CHACHA20_POLY1305_SHA256,
+    ] {
+        let client_cert = generate_self_signed_certificate().expect("gen client cert");
+        let server_cert = generate_self_signed_certificate().expect("gen server cert");
+        let config = dtls12_config_for_suite(suite);
+
+        let mut now = Instant::now();
+
+        let mut client = Dtls::new_12(Arc::clone(&config), client_cert, now);
+        client.set_active(true);
+
+        let mut server = Dtls::new_12(config, server_cert, now);
+        server.set_active(false);
+
+        now = complete_dtls12_handshake(&mut client, &mut server, now);
+
+        for len in 0..dtls12_aead_overhead(suite) {
+            let short = dtls12_epoch1_record(0x100 + len as u64, len);
+            client
+                .handle_packet(&short)
+                .expect("short encrypted record should be silently discarded");
+        }
+
+        server
+            .send_application_data(b"still alive")
+            .expect("server send app data");
+        server.handle_timeout(now).expect("server timeout");
+        let server_out = drain_outputs(&mut server);
+        deliver_packets(&server_out.packets, &mut client);
+
+        client.handle_timeout(now).expect("client timeout");
+        let client_out = drain_outputs(&mut client);
+        assert!(
+            client_out
+                .app_data
+                .iter()
+                .any(|d| d.as_slice() == b"still alive"),
+            "client should receive application data after short encrypted {suite:?} records"
+        );
+    }
 }
 
 #[test]

--- a/tests/dtls12/edge.rs
+++ b/tests/dtls12/edge.rs
@@ -52,7 +52,7 @@ fn dtls12_config_for_suite(suite: Dtls12CipherSuite) -> Arc<Config> {
     )
 }
 
-fn dtls12_aead_overhead(suite: Dtls12CipherSuite) -> usize {
+fn dtls12_min_protected_fragment_len(suite: Dtls12CipherSuite) -> usize {
     match suite {
         Dtls12CipherSuite::ECDHE_ECDSA_AES256_GCM_SHA384
         | Dtls12CipherSuite::ECDHE_ECDSA_AES128_GCM_SHA256 => 24,
@@ -297,7 +297,7 @@ fn dtls12_short_encrypted_records_do_not_panic() {
 
         now = complete_dtls12_handshake(&mut client, &mut server, now);
 
-        for len in 0..dtls12_aead_overhead(suite) {
+        for len in 0..dtls12_min_protected_fragment_len(suite) {
             let short = dtls12_epoch1_record(0x100 + len as u64, len);
             client
                 .handle_packet(&short)

--- a/tests/dtls13/edge.rs
+++ b/tests/dtls13/edge.rs
@@ -103,20 +103,21 @@ fn dtls13_discards_too_short_ciphertext_record() {
 
     now = complete_dtls13_handshake(&mut client, &mut server, now);
 
-    // Craft a DTLS 1.3 ciphertext record with length < 16 bytes.
+    // Every length in [0, AEAD overhead) must be rejected at the record boundary.
+    // For the default DTLS 1.3 suites the AEAD overhead is the tag length (16).
     // Header: fixed bits 001, C=0, S=1 (16-bit seq), L=1 (length), epoch_bits=3
     // => 0b0010_1111 = 0x2F
-    let bogus = vec![
-        0x2F, // unified header byte
-        0x00, 0x01, // encrypted sequence bits
-        0x00, 0x01, // length = 1
-        0x00, // 1 byte ciphertext (too short)
-    ];
+    for len in 0..16u16 {
+        let mut bogus = Vec::with_capacity(5 + len as usize);
+        bogus.push(0x2F);
+        bogus.extend_from_slice(&(0x0100 + len).to_be_bytes()); // encrypted seq bits
+        bogus.extend_from_slice(&len.to_be_bytes());
+        bogus.resize(5 + len as usize, 0);
 
-    // Should be silently discarded (no error)
-    client
-        .handle_packet(&bogus)
-        .expect("too-short ciphertext record should be discarded");
+        client
+            .handle_packet(&bogus)
+            .expect("short ciphertext record should be silently discarded");
+    }
 
     // Verify we can still exchange application data.
     client.send_application_data(b"ping").expect("send app");


### PR DESCRIPTION
## Summary

Discard DTLS 1.2 protected records that are shorter than the mandatory AEAD overhead before attempting decryption.

Before this patch, an epoch-1 record with an undersized encrypted fragment could reach nonce/ciphertext handling and panic in debug/overflow-checking builds. The parser now rejects those records at the incoming-record boundary, and the DTLS 1.2 edge tests cover the regression.

## Validation

- `git diff --check upstream/main..HEAD`
- `cargo fmt --check`
- `cargo test --test dtls12 --features rcgen`
- `cargo test --all-targets --features rcgen`
- `cargo clippy --test dtls12 --features rcgen -- -D warnings`
