### PR TITLE
dtls: reject duplicate supported extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reject duplicate supported DTLS extensions #114
   * Reject malformed DTLS signature_algorithms vectors #111
   * Discard short DTLS 1.2 and 1.3 encrypted records #112
   * Drop late retransmitted DTLS 1.2 CCS after handshake #110

--- a/src/dtls12/message/client_hello.rs
+++ b/src/dtls12/message/client_hello.rs
@@ -199,7 +199,18 @@ impl ClientHello {
 
             // Only keep supported extension types
             if extension.extension_type.is_supported() {
-                extensions.push(extension);
+                if extensions
+                    .iter()
+                    .any(|existing| existing.extension_type == extension.extension_type)
+                {
+                    return Err(Err::Failure(Error::new(
+                        extensions_rest,
+                        ErrorKind::LengthValue,
+                    )));
+                }
+                extensions.try_push(extension).map_err(|_| {
+                    Err::Failure(Error::new(extensions_rest, ErrorKind::LengthValue))
+                })?;
             }
             extensions_rest = rest;
         }
@@ -314,5 +325,28 @@ mod tests {
 
         let result = ClientHello::parse(&message, 0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_supported_extensions_are_rejected() {
+        for count in [2, 9] {
+            let mut message = MESSAGE.to_vec();
+            message.extend_from_slice(&(count as u16 * 4).to_be_bytes());
+            for _ in 0..count {
+                message
+                    .extend_from_slice(&ExtensionType::ExtendedMasterSecret.as_u16().to_be_bytes());
+                message.extend_from_slice(&0u16.to_be_bytes());
+            }
+
+            let result = ClientHello::parse(&message, 0);
+            assert!(
+                matches!(
+                    result,
+                    Err(nom::Err::Failure(error))
+                        if error.code == nom::error::ErrorKind::LengthValue
+                ),
+                "duplicate supported extensions should fail with LengthValue"
+            );
+        }
     }
 }

--- a/src/dtls12/message/server_hello.rs
+++ b/src/dtls12/message/server_hello.rs
@@ -123,7 +123,18 @@ impl ServerHello {
                     current_offset += parsed_len;
                     // Only keep supported extension types
                     if ext.extension_type.is_supported() {
-                        extensions_vec.push(ext);
+                        if extensions_vec
+                            .iter()
+                            .any(|existing| existing.extension_type == ext.extension_type)
+                        {
+                            return Err(Err::Failure(Error::new(
+                                current_input,
+                                ErrorKind::LengthValue,
+                            )));
+                        }
+                        extensions_vec.try_push(ext).map_err(|_| {
+                            Err::Failure(Error::new(current_input, ErrorKind::LengthValue))
+                        })?;
                     }
                     current_input = new_rest;
                 }
@@ -218,5 +229,28 @@ mod test {
 
         let result = ServerHello::parse(&message, 0);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_supported_extensions_are_rejected() {
+        for count in [2, 9] {
+            let mut message = MESSAGE[..39].to_vec();
+            message.extend_from_slice(&(count as u16 * 4).to_be_bytes());
+            for _ in 0..count {
+                message
+                    .extend_from_slice(&ExtensionType::ExtendedMasterSecret.as_u16().to_be_bytes());
+                message.extend_from_slice(&0u16.to_be_bytes());
+            }
+
+            let result = ServerHello::parse(&message, 0);
+            assert!(
+                matches!(
+                    result,
+                    Err(nom::Err::Failure(error))
+                        if error.code == nom::error::ErrorKind::LengthValue
+                ),
+                "duplicate supported extensions should fail with LengthValue"
+            );
+        }
     }
 }

--- a/src/dtls13/message/client_hello.rs
+++ b/src/dtls13/message/client_hello.rs
@@ -111,7 +111,18 @@ impl ClientHello {
             current_offset += parsed_len;
 
             if extension.extension_type.is_supported() {
-                extensions.push(extension);
+                if extensions
+                    .iter()
+                    .any(|existing| existing.extension_type == extension.extension_type)
+                {
+                    return Err(Err::Failure(Error::new(
+                        extensions_rest,
+                        ErrorKind::LengthValue,
+                    )));
+                }
+                extensions.try_push(extension).map_err(|_| {
+                    Err::Failure(Error::new(extensions_rest, ErrorKind::LengthValue))
+                })?;
             }
             extensions_rest = rest;
         }
@@ -257,5 +268,27 @@ mod tests {
             client_hello.extensions.capacity() >= ExtensionType::supported().len(),
             "extensions ArrayVec capacity must fit all supported ExtensionTypes"
         );
+    }
+
+    #[test]
+    fn duplicate_supported_extensions_are_rejected() {
+        for count in [2, 9] {
+            let mut message = MESSAGE.to_vec();
+            message.extend_from_slice(&(count as u16 * 4).to_be_bytes());
+            for _ in 0..count {
+                message.extend_from_slice(&ExtensionType::Cookie.as_u16().to_be_bytes());
+                message.extend_from_slice(&0u16.to_be_bytes());
+            }
+
+            let result = ClientHello::parse(&message, 0);
+            assert!(
+                matches!(
+                    result,
+                    Err(nom::Err::Failure(error))
+                        if error.code == nom::error::ErrorKind::LengthValue
+                ),
+                "duplicate supported extensions should fail with LengthValue"
+            );
+        }
     }
 }

--- a/src/dtls13/message/encrypted_extensions.rs
+++ b/src/dtls13/message/encrypted_extensions.rs
@@ -1,8 +1,10 @@
 use super::Extension;
 use crate::buffer::Buf;
 use arrayvec::ArrayVec;
+use nom::Err;
 use nom::IResult;
 use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 use nom::number::complete::be_u16;
 
 /// EncryptedExtensions message (RFC 8446 Section 4.3.1).
@@ -30,7 +32,15 @@ impl EncryptedExtensions {
             current_offset += parsed_len;
 
             if ext.extension_type.is_supported() {
-                extensions.push(ext);
+                if extensions
+                    .iter()
+                    .any(|existing: &Extension| existing.extension_type == ext.extension_type)
+                {
+                    return Err(Err::Failure(Error::new(rest, ErrorKind::LengthValue)));
+                }
+                extensions
+                    .try_push(ext)
+                    .map_err(|_| Err::Failure(Error::new(rest, ErrorKind::LengthValue)))?;
             }
             rest = new_rest;
         }
@@ -55,6 +65,7 @@ impl EncryptedExtensions {
 
 #[cfg(test)]
 mod tests {
+    use super::super::ExtensionType;
     use super::*;
     use crate::buffer::Buf;
 
@@ -73,5 +84,46 @@ mod tests {
         let mut serialized = Buf::new();
         parsed.serialize(MESSAGE, &mut serialized);
         assert_eq!(&*serialized, MESSAGE);
+    }
+
+    #[test]
+    fn duplicate_supported_extensions_are_rejected() {
+        let mut message = Vec::new();
+        let count = 2;
+        message.extend_from_slice(&(count as u16 * 4).to_be_bytes());
+        for _ in 0..count {
+            message.extend_from_slice(&ExtensionType::Cookie.as_u16().to_be_bytes());
+            message.extend_from_slice(&0u16.to_be_bytes());
+        }
+
+        let result = EncryptedExtensions::parse(&message, 0);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "duplicate supported extensions should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn too_many_distinct_supported_extensions_are_rejected() {
+        let mut message = Vec::new();
+        message.extend_from_slice(&(ExtensionType::supported().len() as u16 * 4).to_be_bytes());
+        for extension_type in ExtensionType::supported() {
+            message.extend_from_slice(&extension_type.as_u16().to_be_bytes());
+            message.extend_from_slice(&0u16.to_be_bytes());
+        }
+
+        let result = EncryptedExtensions::parse(&message, 0);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many distinct supported extensions should fail with LengthValue"
+        );
     }
 }

--- a/src/dtls13/message/server_hello.rs
+++ b/src/dtls13/message/server_hello.rs
@@ -82,7 +82,18 @@ impl ServerHello {
                     let parsed_len = before_len - new_rest.len();
                     current_offset += parsed_len;
                     if ext.extension_type.is_supported() {
-                        extensions_vec.push(ext);
+                        if extensions_vec
+                            .iter()
+                            .any(|existing| existing.extension_type == ext.extension_type)
+                        {
+                            return Err(Err::Failure(Error::new(
+                                current_input,
+                                ErrorKind::LengthValue,
+                            )));
+                        }
+                        extensions_vec.try_push(ext).map_err(|_| {
+                            Err::Failure(Error::new(current_input, ErrorKind::LengthValue))
+                        })?;
                     }
                     current_input = new_rest;
                 }
@@ -132,6 +143,7 @@ impl ServerHello {
 
 #[cfg(test)]
 mod test {
+    use super::super::ExtensionType;
     use super::*;
     use crate::buffer::Buf;
 
@@ -193,5 +205,46 @@ mod test {
     fn normal_server_hello_not_hrr() {
         let (_, parsed) = ServerHello::parse(MESSAGE, 0).unwrap();
         assert!(!parsed.is_hello_retry_request());
+    }
+
+    #[test]
+    fn duplicate_supported_extensions_are_rejected() {
+        let mut message = MESSAGE[..39].to_vec();
+        let count = 2;
+        message.extend_from_slice(&(count as u16 * 4).to_be_bytes());
+        for _ in 0..count {
+            message.extend_from_slice(&ExtensionType::Cookie.as_u16().to_be_bytes());
+            message.extend_from_slice(&0u16.to_be_bytes());
+        }
+
+        let result = ServerHello::parse(&message, 0);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "duplicate supported extensions should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn too_many_distinct_supported_extensions_are_rejected() {
+        let mut message = MESSAGE[..39].to_vec();
+        message.extend_from_slice(&(ExtensionType::supported().len() as u16 * 4).to_be_bytes());
+        for extension_type in ExtensionType::supported() {
+            message.extend_from_slice(&extension_type.as_u16().to_be_bytes());
+            message.extend_from_slice(&0u16.to_be_bytes());
+        }
+
+        let result = ServerHello::parse(&message, 0);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many distinct supported extensions should fail with LengthValue"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- reject duplicate supported extension types while parsing DTLS 1.2 and DTLS 1.3 handshake messages
- convert the remaining fixed-capacity extension pushes to fallible pushes instead of panicking
- add regression coverage and changelog entry

## Validation
- cargo fmt --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings