### PR TITLE
dtls12: replace pending flight output on resend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Replace pending DTLS 1.2 handshake output on resend #116
   * Discard bad protected DTLS 1.2 records after handshake #115
   * Reject oversized DTLS certificate lists #113
   * Reject duplicate supported DTLS extensions #114

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -527,19 +527,36 @@ impl Engine {
 
     fn flight_resend(&mut self, reason: &str) -> Result<(), Error> {
         debug!("Resending flight due to {}", reason);
+
+        let replace_pending_handshake_output = !self.release_app_data;
+
+        if replace_pending_handshake_output {
+            self.queue_tx.clear();
+        }
+
         // For lifetime issues, we take the entries out of self
         let records = mem::take(&mut self.flight_saved_records);
 
-        for entry in &records {
-            self.create_record(entry.content_type, entry.epoch, false, |fragment| {
-                fragment.extend_from_slice(&entry.fragment);
-            })?;
+        let mut result = Ok(());
+        for (index, entry) in records.iter().enumerate() {
+            result = self.create_record_inner(
+                entry.content_type,
+                entry.epoch,
+                false,
+                replace_pending_handshake_output && index == 0,
+                |fragment| {
+                    fragment.extend_from_slice(&entry.fragment);
+                },
+            );
+            if result.is_err() {
+                break;
+            }
         }
 
         // Put the entries back into self
         self.flight_saved_records = records;
 
-        Ok(())
+        result
     }
 
     pub fn has_complete_handshake(&mut self, wanted: MessageType) -> bool {
@@ -671,6 +688,20 @@ impl Engine {
     where
         F: FnOnce(&mut Buf),
     {
+        self.create_record_inner(content_type, epoch, save_fragment, false, f)
+    }
+
+    fn create_record_inner<F>(
+        &mut self,
+        content_type: ContentType,
+        epoch: u16,
+        save_fragment: bool,
+        force_new_datagram: bool,
+        f: F,
+    ) -> Result<(), Error>
+    where
+        F: FnOnce(&mut Buf),
+    {
         let maybe_suite =
             if epoch >= 1 {
                 Some(self.cipher_suite().ok_or_else(|| {
@@ -712,7 +743,7 @@ impl Engine {
         let can_append = self
             .queue_tx
             .back()
-            .map(|b| b.len() + record_wire_len <= self.config.mtu())
+            .map(|b| !force_new_datagram && b.len() + record_wire_len <= self.config.mtu())
             .unwrap_or(false);
 
         // If we cannot append, ensure we have space for a new datagram

--- a/tests/dtls12/retransmit.rs
+++ b/tests/dtls12/retransmit.rs
@@ -296,6 +296,168 @@ fn dtls12_duplicate_triggers_server_resend_of_final_flight() {
 
 #[test]
 #[cfg(feature = "rcgen")]
+fn dtls12_resend_replaces_pending_handshake_flight_tail() {
+    let now0 = Instant::now();
+    let mut now = now0;
+
+    use dimpl::certificate::generate_self_signed_certificate;
+
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+
+    let config_client = Arc::new(
+        Config::builder()
+            .mtu(115)
+            .build()
+            .expect("Failed to build config"),
+    );
+    let config_server = Arc::new(
+        Config::builder()
+            .mtu(115)
+            .build()
+            .expect("Failed to build config"),
+    );
+
+    let expected_initial_headers = {
+        let mut client = Dtls::new_12(Arc::clone(&config_client), client_cert.clone(), now0);
+        client.set_active(true);
+
+        let mut server = Dtls::new_12(Arc::clone(&config_server), server_cert.clone(), now0);
+        server.set_active(false);
+
+        client.handle_timeout(now0).expect("client timeout start");
+        client.handle_timeout(now0).expect("client arm flight 1");
+        for p in collect_packets(&mut client) {
+            server.handle_packet(&p).expect("control server recv f1");
+        }
+
+        server
+            .handle_timeout(now0)
+            .expect("control server arm flight 2");
+        for p in collect_packets(&mut server) {
+            client.handle_packet(&p).expect("control client recv f2");
+        }
+
+        client
+            .handle_timeout(now0)
+            .expect("control client arm flight 3");
+        for p in collect_packets(&mut client) {
+            server.handle_packet(&p).expect("control server recv f3");
+        }
+
+        server
+            .handle_timeout(now0)
+            .expect("control server arm flight 4");
+        collect_headers(&collect_packets(&mut server))
+    };
+    assert!(
+        !expected_initial_headers.is_empty(),
+        "control flight 4 should contain records"
+    );
+
+    let mut client = Dtls::new_12(config_client, client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_12(config_server, server_cert, now);
+    server.set_active(false);
+
+    client.handle_timeout(now).expect("client timeout start");
+    client.handle_timeout(now).expect("client arm flight 1");
+    let f1 = collect_packets(&mut client);
+    for p in f1 {
+        server.handle_packet(&p).expect("server recv f1");
+    }
+
+    server.handle_timeout(now).expect("server arm flight 2");
+    let f2 = collect_packets(&mut server);
+    for p in f2 {
+        client.handle_packet(&p).expect("client recv f2");
+    }
+
+    client.handle_timeout(now).expect("client arm flight 3");
+    let f3 = collect_packets(&mut client);
+    for p in f3 {
+        server.handle_packet(&p).expect("server recv f3");
+    }
+
+    server.handle_timeout(now).expect("server arm flight 4");
+    let first_initial = poll_one_packet(&mut server);
+    let first_initial_headers = parse_records(&first_initial);
+    assert!(
+        !first_initial_headers.is_empty(),
+        "first initial flight 4 packet should contain records"
+    );
+
+    trigger_timeout(&mut server, &mut now);
+    let pending = collect_packets(&mut server);
+    assert!(
+        !pending.is_empty(),
+        "server should emit flight 4 resend after timeout"
+    );
+    let pending_headers = collect_headers(&pending);
+    assert_eq!(
+        pending_headers.len(),
+        expected_initial_headers.len(),
+        "resend should replace the undrained original flight tail instead of appending to it; \
+         expected initial {expected_initial_headers:?}, pending {pending_headers:?}"
+    );
+    assert!(
+        pending_headers
+            .iter()
+            .zip(expected_initial_headers.iter())
+            .all(|(resend, initial)| resend.ctype == initial.ctype
+                && resend.epoch == initial.epoch
+                && resend.seq > initial.seq),
+        "resend should contain only a fresh copy of the flight, got expected initial \
+         {expected_initial_headers:?}, first polled {first_initial_headers:?}, pending \
+         {pending_headers:?}"
+    );
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_final_flight_resend_can_share_post_release_appdata_tail() {
+    let FinalFlightResend {
+        mut server,
+        stale_epoch0_handshake,
+        ..
+    } = prepare_server_final_flight_resend(Config::default().max_queue_rx());
+
+    let filler = vec![0x55; 50];
+    for i in 0..9 {
+        server
+            .send_application_data(&filler)
+            .unwrap_or_else(|err| panic!("queue filler app data {i}: {err:?}"));
+    }
+    server
+        .send_application_data(b"x")
+        .expect("queue final small app data");
+
+    server
+        .handle_packet(&stale_epoch0_handshake)
+        .expect("post-release duplicate should trigger final-flight resend");
+
+    let pending_headers = collect_headers(&collect_packets(&mut server));
+    let app_data_records = pending_headers
+        .iter()
+        .filter(|header| header.ctype == 23 && header.epoch == 1)
+        .count();
+    assert_eq!(
+        app_data_records, 10,
+        "post-release final-flight resend must preserve queued app-data records, got \
+         {pending_headers:?}"
+    );
+    assert!(
+        pending_headers
+            .iter()
+            .any(|header| header.ctype == 22 && header.epoch == 1),
+        "server should retain and resend encrypted final-flight Finished, got \
+         {pending_headers:?}"
+    );
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
 fn dtls12_late_retransmitted_ccs_does_not_pin_receive_queue() {
     //! After the handshake, a peer can still retransmit its final flight. The
     //! epoch-0 ChangeCipherSpec in that flight must be ignored; otherwise it
@@ -426,6 +588,18 @@ fn malformed_epoch0_handshake_packet(sequence_number: u64) -> Vec<u8> {
 fn append_record(mut packet: Vec<u8>, record: &[u8]) -> Vec<u8> {
     packet.extend_from_slice(record);
     packet
+}
+
+#[cfg(feature = "rcgen")]
+fn poll_one_packet(endpoint: &mut Dtls) -> Vec<u8> {
+    let mut buf = vec![0u8; 2048];
+    loop {
+        match endpoint.poll_output(&mut buf) {
+            Output::Packet(packet) => return packet.to_vec(),
+            Output::Timeout(_) => panic!("expected queued packet"),
+            _ => {}
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

When a DTLS 1.2 handshake flight is retransmitted before application data is released, replace any undrained pending handshake output with a fresh resend instead of appending behind the stale tail.

This avoids `TransmitQueueFull` when a timer fires after only part of a previous handshake flight was polled. Post-handshake final-flight resends still preserve queued application data, and saved flight state is restored if a resend attempt fails.

## Validation

- git diff --check
- cargo fmt --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings