### PR TITLE
dtls: reject oversized extension vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Stop DTLS 1.2 flight resends once the peer handshake is confirmed #125
   * Drop plaintext DTLS 1.3 ACKs and alerts after peer encryption #118
+  * Reject oversized DTLS extension vectors #119
   * Replace pending DTLS 1.2 handshake output on resend #116
   * Discard bad protected DTLS 1.2 records after handshake #115
   * Reject oversized DTLS certificate lists #113

--- a/src/dtls12/client.rs
+++ b/src/dtls12/client.rs
@@ -498,17 +498,14 @@ impl State {
             if extension.extension_type == ExtensionType::UseSrtp {
                 // Parse the use_srtp extension to get the selected profile
                 let extension_data = extension.extension_data(&client.defragment_buffer);
-                if let Ok((_, use_srtp)) = UseSrtpExtension::parse(extension_data) {
-                    // Store the first profile as our negotiated profile
-                    if !use_srtp.profiles.is_empty() {
-                        client.negotiated_srtp_profile = Some(use_srtp.profiles[0].into());
-                        trace!(
-                            "ServerHello UseSRTP extension processed; selected profile: {:?}",
-                            client.negotiated_srtp_profile
-                        );
-                    }
-                } else {
-                    warn!("Failed to parse UseSrtp extension");
+                let (_, use_srtp) = UseSrtpExtension::parse(extension_data).map_err(Error::from)?;
+                // Store the first profile as our negotiated profile
+                if !use_srtp.profiles.is_empty() {
+                    client.negotiated_srtp_profile = Some(use_srtp.profiles[0].into());
+                    trace!(
+                        "ServerHello UseSRTP extension processed; selected profile: {:?}",
+                        client.negotiated_srtp_profile
+                    );
                 }
             }
 

--- a/src/dtls12/message/extensions/ec_point_formats.rs
+++ b/src/dtls12/message/extensions/ec_point_formats.rs
@@ -1,6 +1,8 @@
 use crate::buffer::Buf;
 use arrayvec::ArrayVec;
-use nom::{IResult, number::complete::be_u8};
+use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
+use nom::{Err, IResult, number::complete::be_u8};
 
 /// EC Point Format as defined in RFC 4492 Section 5.1.2
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -54,15 +56,31 @@ impl ECPointFormatsExtension {
     #[allow(unused)]
     pub fn parse(input: &[u8]) -> IResult<&[u8], ECPointFormatsExtension> {
         let (input, list_len) = be_u8(input)?;
-        let mut formats = ArrayVec::new();
-        let mut remaining = list_len as usize;
-        let mut current_input = input;
+        let (input, formats_data) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
-        while remaining > 0 {
-            let (rest, format) = ECPointFormat::parse(current_input)?;
-            formats.push(format);
+        let mut formats = ArrayVec::new();
+        let mut current_input = formats_data;
+
+        while !current_input.is_empty() {
+            let format_input = current_input;
+            let (rest, format) = be_u8(current_input)?;
+            let Some(format) = (match format {
+                0x00 => Some(ECPointFormat::Uncompressed),
+                0x01 => Some(ECPointFormat::AnsiX962CompressedPrime),
+                0x02 => Some(ECPointFormat::AnsiX962CompressedChar2),
+                _ => None,
+            }) else {
+                current_input = rest;
+                continue;
+            };
+
+            formats
+                .try_push(format)
+                .map_err(|_| Err::Failure(Error::new(format_input, ErrorKind::LengthValue)))?;
             current_input = rest;
-            remaining -= 1; // Each format is 1 byte
         }
 
         Ok((current_input, ECPointFormatsExtension { formats }))
@@ -106,5 +124,63 @@ mod tests {
         let (_, parsed) = ECPointFormatsExtension::parse(&serialized).unwrap();
 
         assert_eq!(parsed.formats.as_slice(), ext.formats.as_slice());
+    }
+
+    #[test]
+    fn too_many_ec_point_formats_are_rejected() {
+        let bytes = [
+            0x04, // Four point formats.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+        ];
+
+        let err = ECPointFormatsExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn unknown_ec_point_formats_are_ignored() {
+        let (rest, parsed) = ECPointFormatsExtension::parse(&[
+            0x03, // Three point formats.
+            0x02, // ANSI X9.62 compressed char2.
+            0x00, // Uncompressed.
+            0xFF, // Unknown/private point format.
+        ])
+        .unwrap();
+
+        assert!(rest.is_empty());
+        assert_eq!(
+            parsed.formats.as_slice(),
+            &[
+                ECPointFormat::AnsiX962CompressedChar2,
+                ECPointFormat::Uncompressed,
+            ]
+        );
+    }
+
+    #[test]
+    fn trailing_ec_point_format_bytes_are_rejected() {
+        let result = ECPointFormatsExtension::parse(&[
+            0x01, // One point format.
+            0x00, // Uncompressed.
+            0xFF, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(matches!(
+            result,
+            Err(Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            }))
+        ));
     }
 }

--- a/src/dtls12/message/extensions/supported_groups.rs
+++ b/src/dtls12/message/extensions/supported_groups.rs
@@ -1,6 +1,9 @@
 use super::super::{NamedGroup, NamedGroupVec};
 use crate::buffer::Buf;
+use nom::Err;
 use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 
 /// SupportedGroups extension as defined in RFC 8422
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,18 +13,28 @@ pub struct SupportedGroupsExtension {
 
 impl SupportedGroupsExtension {
     pub fn parse(input: &[u8]) -> IResult<&[u8], SupportedGroupsExtension> {
-        let (mut input, list_len) = nom::number::complete::be_u16(input)?;
+        let (input, list_len) = nom::number::complete::be_u16(input)?;
+        if list_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
+        let (input, mut current_input) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         let mut groups = NamedGroupVec::new();
-        let mut remaining = list_len as usize;
 
         // Parse groups; only include supported groups (skip Unknown and unsupported)
-        while remaining >= 2 {
-            let (rest, group) = NamedGroup::parse(input)?;
-            input = rest;
-            remaining -= 2;
+        while !current_input.is_empty() {
+            let group_input = current_input;
+            let (rest, group) = NamedGroup::parse(group_input)?;
+            current_input = rest;
             // Only add supported groups
             if group.is_supported() {
-                groups.push(group);
+                groups
+                    .try_push(group)
+                    .map_err(|_| Err::Failure(Error::new(group_input, ErrorKind::LengthValue)))?;
             }
         }
 
@@ -88,6 +101,61 @@ mod tests {
                 NamedGroup::Secp256r1,
                 NamedGroup::Secp384r1
             ]
+        );
+    }
+
+    #[test]
+    fn too_many_supported_groups_are_rejected() {
+        let mut bytes = Vec::new();
+        let count = NamedGroup::supported().len() + 1;
+        bytes.extend_from_slice(&(count as u16 * 2).to_be_bytes());
+        for _ in 0..count {
+            bytes.extend_from_slice(&NamedGroup::X25519.as_u16().to_be_bytes());
+        }
+
+        let result = SupportedGroupsExtension::parse(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many supported groups should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn odd_supported_groups_vector_is_rejected() {
+        let result = SupportedGroupsExtension::parse(&[
+            0x00, 0x03, // Declared vector length is not divisible by 2.
+            0x00, 0x1D, 0xFF,
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "odd supported_groups vector should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_supported_groups_bytes_are_rejected() {
+        let result = SupportedGroupsExtension::parse(&[
+            0x00, 0x02, // One named group.
+            0x00, 0x1D, // X25519.
+            0xFF, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing supported_groups bytes should fail with LengthValue"
         );
     }
 }

--- a/src/dtls12/message/extensions/use_srtp.rs
+++ b/src/dtls12/message/extensions/use_srtp.rs
@@ -1,9 +1,10 @@
 use crate::SrtpProfile;
 use crate::buffer::Buf;
 use arrayvec::ArrayVec;
-use nom::IResult;
 use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 use nom::number::complete::{be_u8, be_u16};
+use nom::{Err, IResult};
 
 pub type SrtpProfileVec = ArrayVec<SrtpProfileId, { SrtpProfileId::supported().len() }>;
 
@@ -110,21 +111,37 @@ impl UseSrtpExtension {
         let mut profiles_rest = profiles_data;
 
         while profiles_rest.len() >= 2 {
-            let (rest, value) = be_u16(profiles_rest)?;
+            let profile_input = profiles_rest;
+            let (rest, value) = be_u16(profile_input)?;
             profiles_rest = rest;
             match value {
-                0x0001 => profiles.push(SrtpProfileId::SRTP_AES128_CM_SHA1_80),
-                0x0007 => profiles.push(SrtpProfileId::SRTP_AEAD_AES_128_GCM),
-                0x0008 => profiles.push(SrtpProfileId::SRTP_AEAD_AES_256_GCM),
+                0x0001 => profiles
+                    .try_push(SrtpProfileId::SRTP_AES128_CM_SHA1_80)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
+                0x0007 => profiles
+                    .try_push(SrtpProfileId::SRTP_AEAD_AES_128_GCM)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
+                0x0008 => profiles
+                    .try_push(SrtpProfileId::SRTP_AEAD_AES_256_GCM)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
                 _ => {
                     // Unknown SRTP profile: skip
                 }
             }
         }
+        if !profiles_rest.is_empty() {
+            return Err(Err::Failure(Error::new(
+                profiles_rest,
+                ErrorKind::LengthValue,
+            )));
+        }
 
         // Parse MKI
         let (input, mki_length) = be_u8(input)?;
         let (input, mki) = take(mki_length)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
         Ok((
             input,
@@ -210,5 +227,67 @@ mod tests {
             ]
         );
         assert_eq!(parsed.mki, ArrayVec::<u8, 255>::new());
+    }
+
+    #[test]
+    fn too_many_supported_srtp_profiles_are_rejected() {
+        let bytes = [
+            0x00, 0x08, // Four profile IDs.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Empty MKI.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn odd_srtp_profile_vector_is_rejected() {
+        let bytes = [
+            0x00, 0x03, // Odd profile vector length.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Dangling byte in profile vector.
+            0x00, // Empty MKI.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn trailing_mki_bytes_are_rejected() {
+        let bytes = [
+            0x00, 0x02, // One profile ID.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Empty MKI.
+            0xFF, // Trailing extension-body byte.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
     }
 }

--- a/src/dtls12/message/mod.rs
+++ b/src/dtls12/message/mod.rs
@@ -30,6 +30,7 @@ pub use client_hello::ClientHello;
 pub use client_key_exchange::{ClientKeyExchange, ClientPskKeys, ExchangeKeys};
 pub use digitally_signed::DigitallySigned;
 pub use extension::{Extension, ExtensionType};
+pub use extensions::ec_point_formats::ECPointFormatsExtension;
 pub use extensions::signature_algorithms::SignatureAlgorithmsExtension;
 pub use extensions::supported_groups::SupportedGroupsExtension;
 pub use extensions::use_srtp::{SrtpProfileId, SrtpProfileVec, UseSrtpExtension};

--- a/src/dtls12/server.rs
+++ b/src/dtls12/server.rs
@@ -25,6 +25,7 @@ use crate::dtls12::Client;
 use crate::dtls12::client::LocalEvent;
 use crate::dtls12::context::AuthMode;
 use crate::dtls12::engine::Engine;
+use crate::dtls12::message::ECPointFormatsExtension;
 use crate::dtls12::message::PskParams;
 use crate::dtls12::message::{Body, CertificateRequest, CertificateTypeVec, Dtls12CipherSuite};
 use crate::dtls12::message::{ClientCertificateType, CompressionMethod, ContentType};
@@ -412,22 +413,21 @@ impl State {
             match ext.extension_type {
                 ExtensionType::UseSrtp => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    if let Ok((_, use_srtp)) = UseSrtpExtension::parse(ext_data) {
-                        client_srtp_profiles = Some(use_srtp.profiles);
-                    } else {
-                        warn!("Failed to parse UseSrtp extension");
-                    }
+                    let (_, use_srtp) = UseSrtpExtension::parse(ext_data).map_err(Error::from)?;
+                    client_srtp_profiles = Some(use_srtp.profiles);
                 }
                 ExtensionType::ExtendedMasterSecret => {
                     client_offers_ems = true;
                 }
                 ExtensionType::SupportedGroups => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    if let Ok((_, groups)) = SupportedGroupsExtension::parse(ext_data) {
-                        client_supported_groups = Some(groups.groups);
-                    } else {
-                        warn!("Failed to parse SupportedGroups extension");
-                    }
+                    let (_, groups) =
+                        SupportedGroupsExtension::parse(ext_data).map_err(Error::from)?;
+                    client_supported_groups = Some(groups.groups);
+                }
+                ExtensionType::EcPointFormats => {
+                    let ext_data = ext.extension_data(&server.defragment_buffer);
+                    let _ = ECPointFormatsExtension::parse(ext_data).map_err(Error::from)?;
                 }
                 ExtensionType::SignatureAlgorithms => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);

--- a/src/dtls13/client.rs
+++ b/src/dtls13/client.rs
@@ -682,14 +682,13 @@ impl State {
         for ext in &ee.extensions {
             if ext.extension_type == ExtensionType::UseSrtp {
                 let ext_data = ext.extension_data(&client.defragment_buffer);
-                if let Ok((_, use_srtp)) = UseSrtpExtension::parse(ext_data) {
-                    if !use_srtp.profiles.is_empty() {
-                        client.negotiated_srtp_profile = Some(use_srtp.profiles[0].into());
-                        trace!(
-                            "EncryptedExtensions UseSRTP; selected profile: {:?}",
-                            client.negotiated_srtp_profile
-                        );
-                    }
+                let (_, use_srtp) = UseSrtpExtension::parse(ext_data).map_err(Error::from)?;
+                if !use_srtp.profiles.is_empty() {
+                    client.negotiated_srtp_profile = Some(use_srtp.profiles[0].into());
+                    trace!(
+                        "EncryptedExtensions UseSRTP; selected profile: {:?}",
+                        client.negotiated_srtp_profile
+                    );
                 }
             }
         }

--- a/src/dtls13/message/extensions/key_share.rs
+++ b/src/dtls13/message/extensions/key_share.rs
@@ -1,8 +1,10 @@
 use crate::buffer::Buf;
 use crate::types::NamedGroup;
 use arrayvec::ArrayVec;
+use nom::Err;
 use nom::IResult;
 use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 use nom::number::complete::be_u16;
 use std::ops::Range;
 
@@ -48,7 +50,7 @@ impl KeyShareEntry {
 /// KeyShare extension in ClientHello (RFC 8446 Section 4.2.8).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyShareClientHello {
-    pub entries: ArrayVec<KeyShareEntry, 2>,
+    pub entries: ArrayVec<KeyShareEntry, { NamedGroup::supported().len() }>,
 }
 
 impl KeyShareClientHello {
@@ -56,6 +58,9 @@ impl KeyShareClientHello {
         let original_input = input;
         let (input, list_len) = be_u16(input)?;
         let (input, entries_data) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
         let entries_base_offset =
             base_offset + (entries_data.as_ptr() as usize - original_input.as_ptr() as usize);
@@ -67,7 +72,9 @@ impl KeyShareClientHello {
                 entries_base_offset + (rest.as_ptr() as usize - entries_data.as_ptr() as usize);
             let (r, entry) = KeyShareEntry::parse(rest, entry_offset)?;
             if entry.group.is_supported() {
-                entries.push(entry);
+                entries
+                    .try_push(entry)
+                    .map_err(|_| Err::Failure(Error::new(rest, ErrorKind::LengthValue)))?;
             }
             rest = r;
         }
@@ -99,6 +106,10 @@ pub struct KeyShareServerHello {
 impl KeyShareServerHello {
     pub fn parse(input: &[u8], base_offset: usize) -> IResult<&[u8], KeyShareServerHello> {
         let (input, entry) = KeyShareEntry::parse(input, base_offset)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         Ok((input, KeyShareServerHello { entry }))
     }
 
@@ -116,6 +127,10 @@ pub struct KeyShareHelloRetryRequest {
 impl KeyShareHelloRetryRequest {
     pub fn parse(input: &[u8]) -> IResult<&[u8], KeyShareHelloRetryRequest> {
         let (input, selected_group) = NamedGroup::parse(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         Ok((input, KeyShareHelloRetryRequest { selected_group }))
     }
 
@@ -174,5 +189,108 @@ mod tests {
         let mut serialized = Buf::new();
         parsed.serialize(&mut serialized);
         assert_eq!(&*serialized, message);
+    }
+
+    #[test]
+    fn distinct_supported_key_shares_are_accepted() {
+        let mut message = Vec::new();
+        message.extend_from_slice(&(NamedGroup::supported().len() as u16 * 5).to_be_bytes());
+        for group in NamedGroup::supported() {
+            message.extend_from_slice(&group.as_u16().to_be_bytes());
+            message.extend_from_slice(&1u16.to_be_bytes());
+            message.push(0x42);
+        }
+
+        let (rest, parsed) = KeyShareClientHello::parse(&message, 0).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(parsed.entries.len(), NamedGroup::supported().len());
+
+        let mut serialized = Buf::new();
+        parsed.serialize(&message, &mut serialized);
+        assert_eq!(&*serialized, message);
+    }
+
+    #[test]
+    fn too_many_duplicate_supported_key_shares_are_rejected() {
+        let mut message = Vec::new();
+        let count = NamedGroup::supported().len() + 1;
+        message.extend_from_slice(&(count as u16 * 5).to_be_bytes());
+        for _ in 0..count {
+            message.extend_from_slice(&NamedGroup::X25519.as_u16().to_be_bytes());
+            message.extend_from_slice(&1u16.to_be_bytes());
+            message.push(0x42);
+        }
+
+        let result = KeyShareClientHello::parse(&message, 0);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many duplicate key shares should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_client_key_share_bytes_are_rejected() {
+        let result = KeyShareClientHello::parse(
+            &[
+                0x00, 0x08, // client_shares length (8)
+                0x00, 0x1D, // NamedGroup::X25519
+                0x00, 0x04, // key_exchange length
+                0x01, 0x02, 0x03, 0x04, // key_exchange data
+                0xFF, // Extension body has a trailing byte beyond the vector.
+            ],
+            0,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing key_share client bytes should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_server_key_share_bytes_are_rejected() {
+        let result = KeyShareServerHello::parse(
+            &[
+                0x00, 0x1D, // NamedGroup::X25519
+                0x00, 0x04, // key_exchange length
+                0x01, 0x02, 0x03, 0x04, // key_exchange data
+                0xFF, // Extension body has a trailing byte after the entry.
+            ],
+            0,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing key_share server bytes should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_hello_retry_request_key_share_bytes_are_rejected() {
+        let result = KeyShareHelloRetryRequest::parse(&[
+            0x00, 0x1D, // NamedGroup::X25519
+            0xFF, // Extension body has a trailing byte after selected_group.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing key_share HRR bytes should fail with LengthValue"
+        );
     }
 }

--- a/src/dtls13/message/extensions/supported_groups.rs
+++ b/src/dtls13/message/extensions/supported_groups.rs
@@ -1,7 +1,10 @@
 use crate::buffer::Buf;
 use crate::types::NamedGroup;
 use arrayvec::ArrayVec;
+use nom::Err;
 use nom::IResult;
+use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 
 /// SupportedGroups extension as defined in RFC 8422
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,18 +14,28 @@ pub struct SupportedGroupsExtension {
 
 impl SupportedGroupsExtension {
     pub fn parse(input: &[u8]) -> IResult<&[u8], SupportedGroupsExtension> {
-        let (mut input, list_len) = nom::number::complete::be_u16(input)?;
+        let (input, list_len) = nom::number::complete::be_u16(input)?;
+        if list_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
+        let (input, mut current_input) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         let mut groups: ArrayVec<NamedGroup, 4> = ArrayVec::new();
-        let mut remaining = list_len as usize;
 
         // Parse groups; only include supported groups (skip Unknown and unsupported)
-        while remaining >= 2 {
-            let (rest, group) = NamedGroup::parse(input)?;
-            input = rest;
-            remaining -= 2;
+        while !current_input.is_empty() {
+            let group_input = current_input;
+            let (rest, group) = NamedGroup::parse(group_input)?;
+            current_input = rest;
             // Only add supported groups
             if group.is_supported() {
-                groups.push(group);
+                groups
+                    .try_push(group)
+                    .map_err(|_| Err::Failure(Error::new(group_input, ErrorKind::LengthValue)))?;
             }
         }
 
@@ -96,6 +109,61 @@ mod tests {
             ext.groups.capacity(),
             NamedGroup::supported().len(),
             "SupportedGroupsExtension capacity must match all supported NamedGroups"
+        );
+    }
+
+    #[test]
+    fn too_many_supported_groups_are_rejected() {
+        let mut bytes = Vec::new();
+        let count = NamedGroup::supported().len() + 1;
+        bytes.extend_from_slice(&(count as u16 * 2).to_be_bytes());
+        for _ in 0..count {
+            bytes.extend_from_slice(&NamedGroup::X25519.as_u16().to_be_bytes());
+        }
+
+        let result = SupportedGroupsExtension::parse(&bytes);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many supported groups should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn odd_supported_groups_vector_is_rejected() {
+        let result = SupportedGroupsExtension::parse(&[
+            0x00, 0x03, // Declared vector length is not divisible by 2.
+            0x00, 0x1D, 0xFF,
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "odd supported_groups vector should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_supported_groups_bytes_are_rejected() {
+        let result = SupportedGroupsExtension::parse(&[
+            0x00, 0x02, // One named group.
+            0x00, 0x1D, // X25519.
+            0xFF, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing supported_groups bytes should fail with LengthValue"
         );
     }
 }

--- a/src/dtls13/message/extensions/supported_versions.rs
+++ b/src/dtls13/message/extensions/supported_versions.rs
@@ -1,8 +1,10 @@
 use crate::buffer::Buf;
 use crate::types::ProtocolVersion;
 use arrayvec::ArrayVec;
+use nom::Err;
 use nom::IResult;
 use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 use nom::number::complete::be_u8;
 
 /// SupportedVersions extension in ClientHello (RFC 8446 Section 4.2.1).
@@ -14,13 +16,24 @@ pub struct SupportedVersionsClientHello {
 impl SupportedVersionsClientHello {
     pub fn parse(input: &[u8]) -> IResult<&[u8], SupportedVersionsClientHello> {
         let (input, list_len) = be_u8(input)?;
+        if list_len == 0 || list_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         let (input, versions_data) = take(list_len)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
         let mut versions = ArrayVec::new();
         let mut rest = versions_data;
         while !rest.is_empty() {
             let (r, version) = ProtocolVersion::parse(rest)?;
-            versions.push(version);
+            if !matches!(version, ProtocolVersion::Unknown(_)) {
+                versions
+                    .try_push(version)
+                    .map_err(|_| Err::Failure(Error::new(rest, ErrorKind::LengthValue)))?;
+            }
             rest = r;
         }
 
@@ -44,6 +57,10 @@ pub struct SupportedVersionsServerHello {
 impl SupportedVersionsServerHello {
     pub fn parse(input: &[u8]) -> IResult<&[u8], SupportedVersionsServerHello> {
         let (input, selected_version) = ProtocolVersion::parse(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
+
         Ok((input, SupportedVersionsServerHello { selected_version }))
     }
 
@@ -85,5 +102,100 @@ mod tests {
         let mut serialized = Buf::new();
         parsed.serialize(&mut serialized);
         assert_eq!(&*serialized, message);
+    }
+
+    #[test]
+    fn unknown_client_hello_versions_are_ignored() {
+        let message: &[u8] = &[
+            0x08, // list length (8 bytes = 4 versions)
+            0xFE, 0xFC, // DTLS 1.3
+            0xFE, 0xFD, // DTLS 1.2
+            0xFE, 0xFF, // DTLS 1.0
+            0xFE, 0xFE, // Unknown
+        ];
+
+        let (rest, parsed) = SupportedVersionsClientHello::parse(message).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(
+            parsed.versions.as_slice(),
+            &[
+                ProtocolVersion::DTLS1_3,
+                ProtocolVersion::DTLS1_2,
+                ProtocolVersion::DTLS1_0,
+            ]
+        );
+    }
+
+    #[test]
+    fn too_many_duplicate_client_hello_versions_are_rejected() {
+        let message: &[u8] = &[
+            0x08, // list length (8 bytes = 4 versions)
+            0xFE, 0xFC, // DTLS 1.3
+            0xFE, 0xFC, // DTLS 1.3
+            0xFE, 0xFC, // DTLS 1.3
+            0xFE, 0xFC, // DTLS 1.3
+        ];
+
+        let result = SupportedVersionsClientHello::parse(message);
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "too many supported versions should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn odd_client_hello_versions_are_rejected() {
+        let result = SupportedVersionsClientHello::parse(&[
+            0x03, // Declared vector length is not divisible by 2.
+            0xFE, 0xFC, 0xFF,
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "odd supported_versions vector should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_client_hello_versions_bytes_are_rejected() {
+        let result = SupportedVersionsClientHello::parse(&[
+            0x02, // One protocol version.
+            0xFE, 0xFC, // DTLS 1.3.
+            0xFF, // Extension body has a trailing byte beyond the vector.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing supported_versions bytes should fail with LengthValue"
+        );
+    }
+
+    #[test]
+    fn trailing_server_hello_version_bytes_are_rejected() {
+        let result = SupportedVersionsServerHello::parse(&[
+            0xFE, 0xFC, // DTLS 1.3.
+            0xFF, // Extension body has a trailing byte after selected_version.
+        ]);
+
+        assert!(
+            matches!(
+                result,
+                Err(nom::Err::Failure(error))
+                    if error.code == nom::error::ErrorKind::LengthValue
+            ),
+            "trailing selected_version bytes should fail with LengthValue"
+        );
     }
 }

--- a/src/dtls13/message/extensions/use_srtp.rs
+++ b/src/dtls13/message/extensions/use_srtp.rs
@@ -1,9 +1,10 @@
 use crate::SrtpProfile;
 use crate::buffer::Buf;
 use arrayvec::ArrayVec;
-use nom::IResult;
 use nom::bytes::complete::take;
+use nom::error::{Error, ErrorKind};
 use nom::number::complete::{be_u8, be_u16};
+use nom::{Err, IResult};
 
 /// DTLS-SRTP protection profile identifiers
 /// From RFC 5764 Section 4.1.2
@@ -108,21 +109,37 @@ impl UseSrtpExtension {
         let mut profiles_rest = profiles_data;
 
         while profiles_rest.len() >= 2 {
-            let (rest, value) = be_u16(profiles_rest)?;
+            let profile_input = profiles_rest;
+            let (rest, value) = be_u16(profile_input)?;
             profiles_rest = rest;
             match value {
-                0x0001 => profiles.push(SrtpProfileId::SRTP_AES128_CM_SHA1_80),
-                0x0007 => profiles.push(SrtpProfileId::SRTP_AEAD_AES_128_GCM),
-                0x0008 => profiles.push(SrtpProfileId::SRTP_AEAD_AES_256_GCM),
+                0x0001 => profiles
+                    .try_push(SrtpProfileId::SRTP_AES128_CM_SHA1_80)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
+                0x0007 => profiles
+                    .try_push(SrtpProfileId::SRTP_AEAD_AES_128_GCM)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
+                0x0008 => profiles
+                    .try_push(SrtpProfileId::SRTP_AEAD_AES_256_GCM)
+                    .map_err(|_| Err::Failure(Error::new(profile_input, ErrorKind::LengthValue)))?,
                 _ => {
                     // Unknown SRTP profile: skip
                 }
             }
         }
+        if !profiles_rest.is_empty() {
+            return Err(Err::Failure(Error::new(
+                profiles_rest,
+                ErrorKind::LengthValue,
+            )));
+        }
 
         // Parse MKI
         let (input, mki_length) = be_u8(input)?;
         let (input, mki) = take(mki_length)(input)?;
+        if !input.is_empty() {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
 
         Ok((
             input,
@@ -212,5 +229,67 @@ mod tests {
             SrtpProfileId::supported().len(),
             "UseSrtpExtension capacity must match supported profile IDs"
         );
+    }
+
+    #[test]
+    fn too_many_supported_srtp_profiles_are_rejected() {
+        let bytes = [
+            0x00, 0x08, // Four profile IDs.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Empty MKI.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn odd_srtp_profile_vector_is_rejected() {
+        let bytes = [
+            0x00, 0x03, // Odd profile vector length.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Dangling byte in profile vector.
+            0x00, // Empty MKI.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn trailing_mki_bytes_are_rejected() {
+        let bytes = [
+            0x00, 0x02, // One profile ID.
+            0x00, 0x01, // SRTP_AES128_CM_SHA1_80.
+            0x00, // Empty MKI.
+            0xFF, // Trailing extension-body byte.
+        ];
+
+        let err = UseSrtpExtension::parse(&bytes).unwrap_err();
+
+        assert!(matches!(
+            err,
+            Err::Failure(Error {
+                code: ErrorKind::LengthValue,
+                ..
+            })
+        ));
     }
 }

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -416,7 +416,9 @@ impl State {
 
         // Parse extensions
         let mut supported_versions_ok = false;
-        let mut client_key_shares: Option<ArrayVec<(NamedGroup, std::ops::Range<usize>), 2>> = None;
+        let mut client_key_shares: Option<
+            ArrayVec<(NamedGroup, std::ops::Range<usize>), { NamedGroup::supported().len() }>,
+        > = None;
         let mut client_supported_groups: Option<ArrayVec<NamedGroup, 4>> = None;
         let mut client_srtp_profiles: Option<ArrayVec<crate::dtls13::message::SrtpProfileId, 3>> =
             None;
@@ -426,30 +428,31 @@ impl State {
             match ext.extension_type {
                 ExtensionType::SupportedVersions => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    if let Ok((_, sv)) = SupportedVersionsClientHello::parse(ext_data) {
-                        for v in &sv.versions {
-                            if *v == ProtocolVersion::DTLS1_3 {
-                                supported_versions_ok = true;
-                            }
+                    let (_, sv) =
+                        SupportedVersionsClientHello::parse(ext_data).map_err(Error::from)?;
+                    for v in &sv.versions {
+                        if *v == ProtocolVersion::DTLS1_3 {
+                            supported_versions_ok = true;
                         }
                     }
                 }
                 ExtensionType::KeyShare => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
                     let ext_data_start = ext.extension_data_range.start;
-                    if let Ok((_, ks)) = KeyShareClientHello::parse(ext_data, ext_data_start) {
-                        let mut entries = ArrayVec::new();
-                        for entry in &ks.entries {
-                            entries.push((entry.group, entry.key_exchange_range.clone()));
-                        }
-                        client_key_shares = Some(entries);
+                    let (_, ks) = KeyShareClientHello::parse(ext_data, ext_data_start)
+                        .map_err(Error::from)?;
+                    let mut entries = ArrayVec::new();
+                    for entry in &ks.entries {
+                        entries
+                            .try_push((entry.group, entry.key_exchange_range.clone()))
+                            .map_err(|_| Error::ParseError(nom::error::ErrorKind::LengthValue))?;
                     }
+                    client_key_shares = Some(entries);
                 }
                 ExtensionType::SupportedGroups => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    if let Ok((_, sg)) = SupportedGroupsExtension::parse(ext_data) {
-                        client_supported_groups = Some(sg.groups);
-                    }
+                    let (_, sg) = SupportedGroupsExtension::parse(ext_data).map_err(Error::from)?;
+                    client_supported_groups = Some(sg.groups);
                 }
                 ExtensionType::SignatureAlgorithms => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
@@ -458,9 +461,8 @@ impl State {
                 }
                 ExtensionType::UseSrtp => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    if let Ok((_, use_srtp)) = UseSrtpExtension::parse(ext_data) {
-                        client_srtp_profiles = Some(use_srtp.profiles);
-                    }
+                    let (_, use_srtp) = UseSrtpExtension::parse(ext_data).map_err(Error::from)?;
+                    client_srtp_profiles = Some(use_srtp.profiles);
                 }
                 ExtensionType::Cookie => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -898,6 +898,17 @@ mod test {
         Dtls::new_12(config, client_cert, Instant::now())
     }
 
+    fn new_instance_12_no_cookie() -> Dtls {
+        let cert = generate_self_signed_certificate().expect("Failed to generate cert");
+        let config = Arc::new(
+            Config::builder()
+                .use_server_cookie(false)
+                .build()
+                .expect("config"),
+        );
+        Dtls::new_12(config, cert, Instant::now())
+    }
+
     fn new_instance_13() -> Dtls {
         let cert = generate_self_signed_certificate().expect("Failed to generate cert");
         let config = Arc::new(Config::default());
@@ -1120,6 +1131,45 @@ mod test {
         body
     }
 
+    fn dtls13_ch_body_with_extension(extension_type: u16, extension_data: &[u8]) -> Vec<u8> {
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&extension_type.to_be_bytes());
+        extensions.extend_from_slice(&(extension_data.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(extension_data);
+        dtls13_ch_body_with_extensions(&extensions)
+    }
+
+    fn dtls13_ch_body_with_extensions(extensions: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0xFE, 0xFD]); // legacy_version
+        body.extend_from_slice(&[0u8; 32]); // random
+        body.push(0); // legacy_session_id length
+        body.push(0); // legacy_cookie length
+        body.extend_from_slice(&[0x00, 0x02]); // cipher_suites length
+        body.extend_from_slice(&[0x13, 0x01]); // TLS_AES_128_GCM_SHA256
+        body.push(1); // compression_methods length
+        body.push(0); // null compression
+
+        body.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        body.extend_from_slice(extensions);
+        body
+    }
+
+    fn dtls12_ch_body_with_extensions(extensions: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0xFE, 0xFD]); // client_version
+        body.extend_from_slice(&[0u8; 32]); // random
+        body.push(0); // session_id length
+        body.push(0); // cookie length
+        body.extend_from_slice(&[0x00, 0x02]); // cipher_suites length
+        body.extend_from_slice(&[0xC0, 0x2B]); // ECDHE_ECDSA_AES128_GCM_SHA256
+        body.push(1); // compression_methods length
+        body.push(0); // null compression
+        body.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+        body.extend_from_slice(extensions);
+        body
+    }
+
     #[test]
     fn looks_like_client_hello_accepts_minimum_shape_ch() {
         let body = min_ch_body();
@@ -1279,6 +1329,148 @@ mod test {
             fell_back,
             "auto-sense server must fall back to DTLS 1.2 on a CH-shaped malformed packet"
         );
+    }
+
+    #[test]
+    fn dtls13_server_accepts_distinct_supported_key_shares_before_cookie_hrr() {
+        let supported_versions = [
+            0x02, // One protocol version.
+            0xFE, 0xFC, // DTLS 1.3.
+        ];
+
+        let mut supported_groups = Vec::new();
+        supported_groups
+            .extend_from_slice(&(NamedGroup::supported().len() as u16 * 2).to_be_bytes());
+        for group in NamedGroup::supported() {
+            supported_groups.extend_from_slice(&group.as_u16().to_be_bytes());
+        }
+
+        let mut key_share = Vec::new();
+        key_share.extend_from_slice(&(NamedGroup::supported().len() as u16 * 5).to_be_bytes());
+        for group in NamedGroup::supported() {
+            key_share.extend_from_slice(&group.as_u16().to_be_bytes());
+            key_share.extend_from_slice(&1u16.to_be_bytes());
+            key_share.push(0x42);
+        }
+
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&0x002Bu16.to_be_bytes()); // supported_versions
+        extensions.extend_from_slice(&(supported_versions.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&supported_versions);
+        extensions.extend_from_slice(&0x000Au16.to_be_bytes()); // supported_groups
+        extensions.extend_from_slice(&(supported_groups.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&supported_groups);
+        extensions.extend_from_slice(&0x0033u16.to_be_bytes()); // key_share
+        extensions.extend_from_slice(&(key_share.len() as u16).to_be_bytes());
+        extensions.extend_from_slice(&key_share);
+
+        let body = dtls13_ch_body_with_extensions(&extensions);
+        let len = body.len() as u32;
+        let hs = make_handshake(0x01, len, 0, len, &body);
+        let pkt = make_record(0x16, &hs);
+
+        let mut dtls = new_instance_13();
+        dtls.handle_packet(&pkt).expect(
+            "all distinct supported key shares should fit server-side parsing before cookie HRR",
+        );
+    }
+
+    #[test]
+    fn dtls13_server_accepts_unknown_supported_versions_before_cookie_hrr() {
+        let supported_versions = [
+            0x08, // Four protocol versions.
+            0xFE, 0xFE, // Unknown/GREASE-like value.
+            0xFE, 0xFC, // DTLS 1.3.
+            0xFE, 0xFD, // DTLS 1.2.
+            0xFE, 0xFF, // DTLS 1.0.
+        ];
+        let body = dtls13_ch_body_with_extension(0x002B, &supported_versions);
+        let len = body.len() as u32;
+        let hs = make_handshake(0x01, len, 0, len, &body);
+        let pkt = make_record(0x16, &hs);
+
+        let mut dtls = new_instance_13();
+        dtls.handle_packet(&pkt)
+            .expect("unknown supported_versions values should not overflow server-side parsing");
+    }
+
+    #[test]
+    fn dtls12_server_rejects_oversized_ec_point_formats_extension() {
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&[0x00, 0x0B]); // ec_point_formats
+        extensions.extend_from_slice(&[0x00, 0x05]); // extension body length
+        extensions.extend_from_slice(&[
+            0x04, // Four point formats.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+            0x00, // Uncompressed.
+        ]);
+        extensions.extend_from_slice(&[0x00, 0x17]); // extended_master_secret
+        extensions.extend_from_slice(&[0x00, 0x00]); // empty extension body
+
+        let body = dtls12_ch_body_with_extensions(&extensions);
+        let len = body.len() as u32;
+        let hs = make_handshake(0x01, len, 0, len, &body);
+        let pkt = make_record(0x16, &hs);
+
+        let mut dtls = new_instance_12_no_cookie();
+        let err = dtls.handle_packet(&pkt).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ParseError(nom::error::ErrorKind::LengthValue)
+        ));
+    }
+
+    #[test]
+    fn dtls12_server_rejects_trailing_ec_point_formats_extension() {
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&[0x00, 0x0B]); // ec_point_formats
+        extensions.extend_from_slice(&[0x00, 0x03]); // extension body length
+        extensions.extend_from_slice(&[
+            0x01, // One point format.
+            0x00, // Uncompressed.
+            0xFF, // Trailing extension body byte beyond the inner vector.
+        ]);
+        extensions.extend_from_slice(&[0x00, 0x17]); // extended_master_secret
+        extensions.extend_from_slice(&[0x00, 0x00]); // empty extension body
+
+        let body = dtls12_ch_body_with_extensions(&extensions);
+        let len = body.len() as u32;
+        let hs = make_handshake(0x01, len, 0, len, &body);
+        let pkt = make_record(0x16, &hs);
+
+        let mut dtls = new_instance_12_no_cookie();
+        let err = dtls.handle_packet(&pkt).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::ParseError(nom::error::ErrorKind::LengthValue)
+        ));
+    }
+
+    #[test]
+    fn dtls12_server_accepts_unknown_ec_point_formats_extension() {
+        let mut extensions = Vec::new();
+        extensions.extend_from_slice(&[0x00, 0x0B]); // ec_point_formats
+        extensions.extend_from_slice(&[0x00, 0x04]); // extension body length
+        extensions.extend_from_slice(&[
+            0x03, // Three point formats.
+            0x02, // ANSI X9.62 compressed char2.
+            0x00, // Uncompressed.
+            0xFF, // Unknown/private point format.
+        ]);
+        extensions.extend_from_slice(&[0x00, 0x17]); // extended_master_secret
+        extensions.extend_from_slice(&[0x00, 0x00]); // empty extension body
+
+        let body = dtls12_ch_body_with_extensions(&extensions);
+        let len = body.len() as u32;
+        let hs = make_handshake(0x01, len, 0, len, &body);
+        let pkt = make_record(0x16, &hs);
+
+        let mut dtls = new_instance_12_no_cookie();
+        dtls.handle_timeout(Instant::now()).unwrap();
+        dtls.handle_packet(&pkt)
+            .expect("unknown ec_point_formats values should not fail server-side parsing");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject oversized bounded vectors in DTLS extension parsers instead of panicking or silently truncating
- reject malformed inner extension vectors with odd lengths or trailing bytes when parsing exact extension bodies
- propagate hard extension parser failures through auto server handling instead of falling back to DTLS 1.2

## Tests
- `cargo fmt --manifest-path extern/scratch/dimpl/workspaces/DIMP-012/Cargo.toml --check`
- `cargo test --manifest-path extern/scratch/dimpl/workspaces/DIMP-012/Cargo.toml --all-targets --features rcgen`
- `cargo clippy --manifest-path extern/scratch/dimpl/workspaces/DIMP-012/Cargo.toml --all-targets --features rcgen -- -D warnings`
- `cargo test --manifest-path extern/scratch/dimpl/workspaces/DIMP-012/Cargo.toml --features rcgen trailing`
- `cargo test --manifest-path extern/scratch/dimpl/workspaces/DIMP-012/Cargo.toml --features rcgen oversized`
