### PR TITLE
dtls12: stop flight resends once peer handshake is confirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Stop DTLS 1.2 flight resends once the peer handshake is confirmed #125
   * Replace pending DTLS 1.2 handshake output on resend #116
   * Discard bad protected DTLS 1.2 records after handshake #115
   * Reject oversized DTLS certificate lists #113

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -321,29 +321,6 @@ impl Engine {
         let first = incoming.first();
         let seq_current = first.record().sequence;
 
-        // Authenticated application data proves the peer is past its handshake,
-        // so it has received our final flight. This is the server's signal that
-        // the client completed (the client itself confirms at completion, in
-        // flight_stop_resend_timers).
-        //
-        // The release_app_data guard is what makes this authenticated: a DTLS
-        // 1.2 record advertises its content type in the cleartext header, and
-        // epoch-1 records that arrive before peer encryption is enabled are
-        // queued undecrypted. Without the guard a forged epoch-1 record with an
-        // ApplicationData header could set this off unauthenticated data. Once
-        // release_app_data is set, peer encryption is on, so any epoch-1 record
-        // that reaches here was decrypted (a forgery fails AEAD in Record::parse
-        // and never arrives).
-        if self.release_app_data
-            && !self.peer_handshake_confirmed
-            && incoming.records().iter().any(|r| {
-                r.record().sequence.epoch >= 1
-                    && r.record().content_type == ContentType::ApplicationData
-            })
-        {
-            self.peer_handshake_confirmed = true;
-        }
-
         if self.peer_encryption_enabled
             && seq_current.epoch == 0
             && first.record().content_type == ContentType::Handshake
@@ -1358,6 +1335,17 @@ impl RecordHandler for Engine {
 
     fn replay_update(&mut self, seq: Sequence) {
         self.replay.update(seq.sequence_number);
+    }
+
+    fn note_decrypted_record(&mut self, content_type: ContentType) {
+        // A decrypted (so authenticated) application-data record proves the peer
+        // is past its handshake, which means it received our final flight. Once
+        // that's known, a stale plaintext handshake (unauthenticated, replayable)
+        // must no longer drive a courtesy flight retransmission. The client
+        // confirms separately at its own completion (flight_stop_resend_timers).
+        if content_type == ContentType::ApplicationData {
+            self.peer_handshake_confirmed = true;
+        }
     }
 
     fn decryption_aad_and_nonce(&self, dtls: &DTLSRecord, buf: &[u8]) -> (Aad, Nonce) {

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -325,7 +325,17 @@ impl Engine {
         // so it has received our final flight. This is the server's signal that
         // the client completed (the client itself confirms at completion, in
         // flight_stop_resend_timers).
-        if !self.peer_handshake_confirmed
+        //
+        // The release_app_data guard is what makes this authenticated: a DTLS
+        // 1.2 record advertises its content type in the cleartext header, and
+        // epoch-1 records that arrive before peer encryption is enabled are
+        // queued undecrypted. Without the guard a forged epoch-1 record with an
+        // ApplicationData header could set this off unauthenticated data. Once
+        // release_app_data is set, peer encryption is on, so any epoch-1 record
+        // that reaches here was decrypted (a forgery fails AEAD in Record::parse
+        // and never arrives).
+        if self.release_app_data
+            && !self.peer_handshake_confirmed
             && incoming.records().iter().any(|r| {
                 r.record().sequence.epoch >= 1
                     && r.record().content_type == ContentType::ApplicationData

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -94,6 +94,18 @@ pub struct Engine {
     /// Whether we are ready to release application data from poll_output.
     release_app_data: bool,
 
+    /// Whether we have confirmation that the peer completed the handshake, i.e.
+    /// that the peer received our final flight. Once set, a stale plaintext
+    /// handshake (which is unauthenticated and replayable after encryption is
+    /// enabled) no longer triggers a courtesy flight retransmission.
+    ///
+    /// This is set from two signals, each meaningful for one role:
+    /// - the client stops its resend timer when it completes, which means the
+    ///   server received our final flight (the client confirms at completion);
+    /// - receiving authenticated application data, which means the peer is past
+    ///   its handshake (the server's only proof the client received flight 6).
+    peer_handshake_confirmed: bool,
+
     /// Whether a close_notify alert has been received from the peer.
     close_notify_received: bool,
 
@@ -147,6 +159,7 @@ impl Engine {
             flight_timeout: Timeout::Unarmed,
             connect_timeout: Timeout::Unarmed,
             release_app_data: false,
+            peer_handshake_confirmed: false,
             close_notify_received: false,
             close_notify_reported: false,
         }
@@ -254,9 +267,12 @@ impl Engine {
             .next();
 
         // Some MessageType when resent, means we must trigger
-        // an immediate resend of the entire flight.
+        // an immediate resend of the entire flight. Once the peer is confirmed
+        // to have completed the handshake, a stale plaintext handshake is just
+        // unauthenticated noise (or a replay/amplification attempt) and must not
+        // drive a resend.
         if let Some(dupe_seq) = maybe_dupe_seq {
-            if dupe_seq < self.peer_handshake_seq_no {
+            if dupe_seq < self.peer_handshake_seq_no && !self.peer_handshake_confirmed {
                 self.flight_resend("dupe triggers resend")?;
             }
         }
@@ -304,6 +320,19 @@ impl Engine {
     fn insert_incoming_non_handshake(&mut self, incoming: Incoming) -> Result<(), Error> {
         let first = incoming.first();
         let seq_current = first.record().sequence;
+
+        // Authenticated application data proves the peer is past its handshake,
+        // so it has received our final flight. This is the server's signal that
+        // the client completed (the client itself confirms at completion, in
+        // flight_stop_resend_timers).
+        if !self.peer_handshake_confirmed
+            && incoming.records().iter().any(|r| {
+                r.record().sequence.epoch >= 1
+                    && r.record().content_type == ContentType::ApplicationData
+            })
+        {
+            self.peer_handshake_confirmed = true;
+        }
 
         if self.peer_encryption_enabled
             && seq_current.epoch == 0
@@ -517,6 +546,16 @@ impl Engine {
         debug!("Stop connect and flight timeouts");
         self.flight_timeout = Timeout::Disabled;
         self.connect_timeout = Timeout::Disabled;
+
+        // The client stops its resend timer only once it has received the
+        // server's final flight, which proves the server received the client's
+        // final flight — so the peer is confirmed. The server, by contrast,
+        // stops its timer right after sending flight 6, before the client has
+        // confirmed anything, so it must NOT confirm here (it relies on later
+        // authenticated application data instead).
+        if self.is_client {
+            self.peer_handshake_confirmed = true;
+        }
     }
 
     fn flight_clear_resends(&mut self) {

--- a/src/dtls12/incoming.rs
+++ b/src/dtls12/incoming.rs
@@ -168,6 +168,7 @@ impl Record {
         // We need to decrypt the record and redo the parsing.
         let dtls = record.record();
         let sequence = dtls.sequence;
+        let content_type = dtls.content_type;
 
         // Anti-replay check (read-only, does not update window)
         if !decrypt.replay_check(sequence) {
@@ -213,6 +214,10 @@ impl Record {
         // RFC 6347 §4.1.2.6: "The receive window is updated only if the
         // MAC verification succeeds."
         decrypt.replay_update(sequence);
+
+        // The record is now authenticated. Tell the handler so it can act on a
+        // confirmed-genuine record (e.g. mark the peer past its handshake).
+        decrypt.note_decrypted_record(content_type);
 
         // Update the length of the record.
         buffer[11] = (new_len >> 8) as u8;
@@ -314,6 +319,11 @@ pub trait RecordHandler {
     fn can_discard_bad_protected_record(&self) -> bool {
         false
     }
+
+    /// Called once a record has been successfully decrypted, i.e. authenticated.
+    /// Lets the handler react to a confirmed-genuine record (e.g. note that the
+    /// peer is past its handshake). The default does nothing.
+    fn note_decrypted_record(&mut self, _content_type: ContentType) {}
 }
 
 fn parse_handshakes(

--- a/tests/dtls12/retransmit.rs
+++ b/tests/dtls12/retransmit.rs
@@ -1123,3 +1123,106 @@ fn dtls12_stale_client_hello_after_peer_confirmed_triggers_no_resend() {
         "server must not resend its flight after the client is confirmed connected"
     );
 }
+
+#[cfg(feature = "rcgen")]
+fn forged_epoch1_app_data() -> Vec<u8> {
+    // A DTLS 1.2 record header advertising epoch-1 ApplicationData with a
+    // garbage (undecryptable) body. The content type lives in the cleartext
+    // header, so this looks like app data before anything is decrypted.
+    let mut rec = Vec::new();
+    rec.push(23); // ContentType::ApplicationData
+    rec.extend_from_slice(&[0xFE, 0xFD]); // DTLS 1.2
+    rec.extend_from_slice(&1u16.to_be_bytes()); // epoch 1
+    rec.extend_from_slice(&[0, 0, 0, 0, 0, 1]); // 48-bit sequence number
+    rec.extend_from_slice(&2u16.to_be_bytes()); // fragment length
+    rec.extend_from_slice(&[0xAA, 0xBB]); // garbage fragment
+    rec
+}
+
+/// A forged epoch-1 application-data record arriving before peer encryption is
+/// enabled must not confirm the peer handshake. The record advertises
+/// ApplicationData in its cleartext header and is queued undecrypted, so without
+/// the authentication guard it would falsely mark the peer confirmed and suppress
+/// the flight-6 resend that a genuinely lost flight needs.
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_forged_epoch1_appdata_before_encryption_does_not_confirm_peer() {
+    use dimpl::certificate::generate_self_signed_certificate;
+
+    let _ = env_logger::try_init();
+
+    let mut now = Instant::now();
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+    let config_client = Arc::new(Config::builder().mtu(115).build().expect("config"));
+    let config_server = Arc::new(Config::builder().mtu(115).build().expect("config"));
+
+    let mut client = Dtls::new_12(config_client, client_cert, now);
+    client.set_active(true);
+    let mut server = Dtls::new_12(config_server, server_cert, now);
+    server.set_active(false);
+
+    // Flight 1: ClientHello.
+    client.handle_timeout(now).expect("client timeout start");
+    client.handle_timeout(now).expect("client arm flight 1");
+    let f1 = collect_packets(&mut client);
+    for packet in &f1 {
+        server.handle_packet(packet).expect("server recv f1");
+    }
+
+    // Flight 2: HelloVerifyRequest.
+    server.handle_timeout(now).expect("server arm flight 2");
+    let f2 = collect_packets(&mut server);
+    assert!(!f2.is_empty(), "server should emit flight 2");
+    for packet in &f2 {
+        client.handle_packet(packet).expect("client recv f2");
+    }
+
+    // Flight 3: ClientHello with cookie.
+    client.handle_timeout(now).expect("client arm flight 3");
+    let f3 = collect_packets(&mut client);
+    assert!(!f3.is_empty(), "client should emit flight 3");
+    for packet in &f3 {
+        server.handle_packet(packet).expect("server recv f3");
+    }
+
+    // Flight 4: server hello flight.
+    server.handle_timeout(now).expect("server arm flight 4");
+    let f4 = collect_packets(&mut server);
+    assert!(!f4.is_empty(), "server should emit flight 4");
+    for packet in &f4 {
+        client.handle_packet(packet).expect("client recv f4");
+    }
+
+    // Inject the forged epoch-1 app-data record while the server still has peer
+    // encryption disabled (it has not seen the client CCS yet).
+    let _ = server.handle_packet(&forged_epoch1_app_data());
+    let _ = drain_outputs(&mut server);
+
+    // Flight 5: CKE, CCS, Finished. Server completes and emits flight 6.
+    client.handle_timeout(now).expect("client arm flight 5");
+    let f5 = collect_packets(&mut client);
+    assert!(!f5.is_empty(), "client should emit flight 5");
+    for packet in &f5 {
+        server.handle_packet(packet).expect("server recv f5");
+    }
+    server.handle_timeout(now).expect("server arm flight 6");
+    let f6_init = collect_packets(&mut server);
+    assert!(!f6_init.is_empty(), "server should emit flight 6");
+
+    // Drop flight 6. The client retransmits flight 5 on timeout.
+    trigger_timeout(&mut client, &mut now);
+    let f5_resend = collect_packets(&mut client);
+    assert!(!f5_resend.is_empty(), "client should resend flight 5");
+    for packet in &f5_resend {
+        server.handle_packet(packet).expect("server recv f5 resend");
+    }
+
+    // The forged record must not have confirmed the peer, so the duplicate
+    // flight 5 still drives a flight-6 resend.
+    let f6_resend = collect_packets(&mut server);
+    assert!(
+        !f6_resend.is_empty(),
+        "forged pre-encryption app data must not confirm the peer; flight 6 must still resend"
+    );
+}

--- a/tests/dtls12/retransmit.rs
+++ b/tests/dtls12/retransmit.rs
@@ -1040,3 +1040,86 @@ fn dtls12_handshake_timeout_aborts() {
         "Client should report a timeout error when handshake_timeout is exceeded"
     );
 }
+
+/// Before the peer is confirmed (the legitimate retransmission window), a stale
+/// plaintext ClientHello still triggers a flight-6 resend, so a lost flight 6
+/// recovers. This is the contrast case to the post-confirmation suppression
+/// below: the gate must not break legitimate retransmission.
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_stale_client_hello_before_peer_confirmed_triggers_resend() {
+    let _ = env_logger::try_init();
+
+    const RX_QUEUE_LIMIT: usize = 8;
+    let FinalFlightResend {
+        mut server,
+        stale_epoch0_handshake,
+        ..
+    } = prepare_server_final_flight_resend(RX_QUEUE_LIMIT);
+
+    // The server has sent flight 6 but has no confirmation the client received
+    // it (no authenticated application data has arrived). A stale ClientHello
+    // here means "peer still needs my flight" and must drive a resend.
+    server
+        .handle_packet(&stale_epoch0_handshake)
+        .expect("stale ClientHello must be tolerated");
+    let resend = collect_packets(&mut server);
+
+    assert!(
+        !resend.is_empty(),
+        "server must resend flight 6 on a stale ClientHello while the peer is unconfirmed"
+    );
+}
+
+/// Once the peer is confirmed to have completed the handshake (the server has
+/// received authenticated application data from the client), a replayed
+/// plaintext ClientHello is unauthenticated noise and must not trigger a flight
+/// retransmission. This closes the resend-amplification window that an attacker
+/// could otherwise drive with spoofed epoch-0 handshakes.
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_stale_client_hello_after_peer_confirmed_triggers_no_resend() {
+    let _ = env_logger::try_init();
+
+    const RX_QUEUE_LIMIT: usize = 8;
+    let FinalFlightResend {
+        mut client,
+        mut server,
+        f6_resend,
+        stale_epoch0_handshake,
+        ..
+    } = prepare_server_final_flight_resend(RX_QUEUE_LIMIT);
+
+    // Finish the handshake: deliver the server's resent flight 6 to the client.
+    deliver_packets(&f6_resend, &mut client);
+    assert!(
+        drain_outputs(&mut client).connected,
+        "client should connect once it receives flight 6"
+    );
+
+    // Client application data is the server's signal that the client completed
+    // (it could only send it after receiving flight 6).
+    client
+        .send_application_data(b"client-app-data")
+        .expect("client sends application data");
+    let client_app = collect_packets(&mut client);
+    assert!(!client_app.is_empty(), "client should emit app-data packet");
+    deliver_packets(&client_app, &mut server);
+    let server_out = drain_outputs(&mut server);
+    assert_eq!(
+        server_out.app_data,
+        vec![b"client-app-data".to_vec()],
+        "server should receive the client's application data"
+    );
+
+    // Replay the stale plaintext ClientHello at the now-confirmed server.
+    server
+        .handle_packet(&stale_epoch0_handshake)
+        .expect("stale ClientHello must be tolerated");
+    let resend = collect_packets(&mut server);
+
+    assert!(
+        resend.is_empty(),
+        "server must not resend its flight after the client is confirmed connected"
+    );
+}


### PR DESCRIPTION
## Summary

Supersedes #117. After DTLS 1.2 peer encryption is enabled, an epoch-0 plaintext handshake record is unauthenticated and replayable. The reactive flight resend in `insert_incoming_handshake` was driven purely by such records, so a peer that had already completed the handshake — or an attacker replaying a captured ClientHello — could keep forcing our final flight to be retransmitted indefinitely (a resend-amplification lever on spoofable input).

This gates the reactive resend on a new `peer_handshake_confirmed` flag instead of trying to salvage/preserve records around the stale prefix.

## Why this approach (vs #117)

#117 attacked the symptom: it dropped the stale handshake in `classify_record` and tried to *preserve the encrypted tail*. That had three problems:
- **Wrong objective** — a `[plaintext handshake][encrypted records]` datagram is something no legitimate peer produces for deliverable app data (only a retransmitted flight 5, whose tail is a duplicate Finished). Such datagrams are adversarial and should be discarded, not salvaged.
- **Wrong layer** — it fired a *send* (`flight_resend`) from inside the *receive*/parse path (`classify_record`), so parsing an inbound record could fail with `TransmitQueueFull`.
- **Wrong error category** — it then swallowed `TransmitQueueFull`, which under the Poll-to-Timeout contract is a fatal structural error, not recoverable backpressure.

The root cause was that the resend was triggered by spoofable stale handshakes even after the peer had completed. Removing that trigger once the peer is confirmed makes the stale handshake pure noise that the existing code already drops — no tail-preservation, no send-in-receive-path, no `TransmitQueueFull` handling.

## How `peer_handshake_confirmed` is set

Two signals, each meaningful for one role (the other is a harmless no-op — the last-flight problem is asymmetric):

- **Client**: confirms when it stops its resend timer at completion (`flight_stop_resend_timers`, gated on `is_client`). Receiving the server's final flight proves the server received the client's final flight.
- **Server**: confirms on the first authenticated epoch-1 application data from the peer (`insert_incoming_non_handshake`). That is the server's only proof the client received flight 6. The server must **not** confirm at its own completion, since it stops its timer right after sending flight 6, before the client has it.

The legitimate retransmission window is preserved: while unconfirmed, a stale handshake still triggers a resend, so a lost final flight still recovers.

## Tests

`tests/dtls12/retransmit.rs`:
- `dtls12_stale_client_hello_before_peer_confirmed_triggers_resend` — legit window: a stale ClientHello still drives a flight-6 resend.
- `dtls12_stale_client_hello_after_peer_confirmed_triggers_no_resend` — once the server has seen the client's app data, a replayed ClientHello produces no resend.

The existing `prepare_server_final_flight_resend` helper (and the suite's other retransmit/queue-pinning guards) continue to pass, covering the unconfirmed-window resend.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets --features rcgen` (193 + 62 + 69 + 109 tests, 0 failed)
- `cargo clippy --all-targets --features rcgen -- -D warnings`