### PR TITLE
dtls13: reject malformed cookie extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reject malformed DTLS 1.3 Cookie extension bodies #128
   * Bound DTLS 1.3 ACK tracking during handshake replacement #120
   * Stop DTLS 1.2 flight resends once the peer handshake is confirmed #125
   * Drop plaintext DTLS 1.3 ACKs and alerts after peer encryption #118

--- a/src/dtls13/client.rs
+++ b/src/dtls13/client.rs
@@ -58,6 +58,7 @@ use crate::dtls13::message::SupportedGroupsExtension;
 use crate::dtls13::message::SupportedVersionsClientHello;
 use crate::dtls13::message::SupportedVersionsServerHello;
 use crate::dtls13::message::UseSrtpExtension;
+use crate::dtls13::message::parse_cookie_extension;
 use crate::{Error, KeyingMaterial, Output};
 
 /// DTLS 1.3 client
@@ -473,16 +474,10 @@ impl State {
                         }
                         ExtensionType::Cookie => {
                             let ext_data = ext.extension_data(&client.defragment_buffer);
-                            // Cookie extension format: cookie<1..2^16-1> (u16 length prefix)
-                            if ext_data.len() >= 2 {
-                                let cookie_len =
-                                    u16::from_be_bytes([ext_data[0], ext_data[1]]) as usize;
-                                if ext_data.len() >= 2 + cookie_len {
-                                    let mut cookie = Buf::new();
-                                    cookie.extend_from_slice(&ext_data[..2 + cookie_len]);
-                                    client.saved_cookie = Some(cookie);
-                                }
-                            }
+                            parse_cookie_extension(ext_data).map_err(Error::from)?;
+                            let mut cookie = Buf::new();
+                            cookie.extend_from_slice(ext_data);
+                            client.saved_cookie = Some(cookie);
                         }
                         _ => {}
                     }

--- a/src/dtls13/message/extensions/cookie.rs
+++ b/src/dtls13/message/extensions/cookie.rs
@@ -1,0 +1,54 @@
+use nom::Err;
+use nom::IResult;
+use nom::error::{Error, ErrorKind};
+use nom::number::complete::be_u16;
+
+/// Parse the DTLS 1.3 Cookie extension body.
+///
+/// RFC 8446 defines the extension payload as `cookie<1..2^16-1>`,
+/// so the extension body is a u16 length followed by exactly that many bytes.
+pub(crate) fn parse_cookie_extension(input: &[u8]) -> IResult<&[u8], &[u8]> {
+    if input.len() < 2 {
+        return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+    }
+
+    let (rest, cookie_len) = be_u16(input)?;
+    if cookie_len == 0 || rest.len() != cookie_len as usize {
+        return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+    }
+
+    Ok((&[], rest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_cookie_vectors_are_rejected() {
+        for input in [
+            &[][..],
+            &[0x00],
+            &[0x00, 0x00],
+            &[0x00, 0x02, 0xAA],
+            &[0x00, 0x01, 0xAA, 0xBB],
+        ] {
+            let result = parse_cookie_extension(input);
+            assert!(
+                matches!(
+                    result,
+                    Err(nom::Err::Failure(error))
+                        if error.code == nom::error::ErrorKind::LengthValue
+                ),
+                "malformed cookie vector should fail with LengthValue: {input:02x?}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_cookie_vector_is_accepted() {
+        let (rest, cookie) = parse_cookie_extension(&[0x00, 0x02, 0xAA, 0xBB]).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(cookie, &[0xAA, 0xBB]);
+    }
+}

--- a/src/dtls13/message/extensions/mod.rs
+++ b/src/dtls13/message/extensions/mod.rs
@@ -1,3 +1,4 @@
+pub mod cookie;
 pub mod key_share;
 pub mod signature_algorithms;
 pub mod supported_groups;

--- a/src/dtls13/message/mod.rs
+++ b/src/dtls13/message/mod.rs
@@ -23,6 +23,7 @@ pub use client_hello::ClientHello;
 pub use digitally_signed::DigitallySigned;
 pub use encrypted_extensions::EncryptedExtensions;
 pub use extension::{Extension, ExtensionType};
+pub(crate) use extensions::cookie::parse_cookie_extension;
 pub use extensions::key_share::{
     KeyShareClientHello, KeyShareEntry, KeyShareHelloRetryRequest, KeyShareServerHello,
 };

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -66,6 +66,7 @@ use crate::dtls13::message::SupportedGroupsExtension;
 use crate::dtls13::message::SupportedVersionsClientHello;
 use crate::dtls13::message::SupportedVersionsServerHello;
 use crate::dtls13::message::UseSrtpExtension;
+use crate::dtls13::message::parse_cookie_extension;
 use crate::{Config, DtlsCertificate, Error, Output};
 
 /// Magic random value indicating HelloRetryRequest (RFC 8446 Section 4.1.3).
@@ -466,15 +467,10 @@ impl State {
                 }
                 ExtensionType::Cookie => {
                     let ext_data = ext.extension_data(&server.defragment_buffer);
-                    // Cookie extension format: cookie<1..2^16-1>
-                    // Length-prefixed with u16
-                    if ext_data.len() >= 2 {
-                        let cookie_len = u16::from_be_bytes([ext_data[0], ext_data[1]]) as usize;
-                        if ext_data.len() >= 2 + cookie_len {
-                            client_cookie_data =
-                                ArrayVec::try_from(&ext_data[2..2 + cookie_len]).ok();
-                        }
-                    }
+                    let (_, cookie) = parse_cookie_extension(ext_data).map_err(Error::from)?;
+                    client_cookie_data = Some(ArrayVec::try_from(cookie).map_err(|_| {
+                        Error::SecurityError("Invalid cookie in ClientHello".to_string())
+                    })?);
                 }
                 _ => {}
             }

--- a/tests/dtls13_cookie.rs
+++ b/tests/dtls13_cookie.rs
@@ -1,0 +1,202 @@
+#![cfg(feature = "rcgen")]
+
+#[path = "dtls13/common.rs"]
+mod common;
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use dimpl::Dtls;
+use dimpl::certificate::generate_self_signed_certificate;
+
+use crate::common::{drain_outputs, dtls13_config};
+
+fn cookie_extensions_start(body: &[u8], msg_type: u8) -> Option<usize> {
+    let mut pos = 0;
+    match msg_type {
+        0x01 => {
+            pos += 2 + 32;
+            let sid_len = *body.get(pos)? as usize;
+            pos += 1 + sid_len;
+            let cookie_len = *body.get(pos)? as usize;
+            pos += 1 + cookie_len;
+            let suites_len = u16::from_be_bytes([*body.get(pos)?, *body.get(pos + 1)?]) as usize;
+            pos += 2 + suites_len;
+            let compression_len = *body.get(pos)? as usize;
+            pos += 1 + compression_len;
+        }
+        0x02 => {
+            pos += 2 + 32;
+            let sid_len = *body.get(pos)? as usize;
+            pos += 1 + sid_len + 2 + 1;
+        }
+        _ => return None,
+    }
+
+    Some(pos)
+}
+
+fn shrink_dtls13_cookie_extension_inner_len(packet: &mut [u8]) -> bool {
+    const RECORD_HEADER_LEN: usize = 13;
+    const HANDSHAKE_HEADER_LEN: usize = 12;
+    const COOKIE_EXTENSION: u16 = 0x002C;
+
+    if packet.len() < RECORD_HEADER_LEN + HANDSHAKE_HEADER_LEN || packet[0] != 22 {
+        return false;
+    }
+
+    let handshake = &mut packet[RECORD_HEADER_LEN..];
+    let msg_type = handshake[0];
+    let body_len =
+        ((handshake[1] as usize) << 16) | ((handshake[2] as usize) << 8) | handshake[3] as usize;
+    if handshake.len() < HANDSHAKE_HEADER_LEN + body_len {
+        return false;
+    }
+
+    let body = &mut handshake[HANDSHAKE_HEADER_LEN..HANDSHAKE_HEADER_LEN + body_len];
+    let mut pos = match cookie_extensions_start(body, msg_type) {
+        Some(pos) => pos,
+        None => return false,
+    };
+    if body.len() < pos + 2 {
+        return false;
+    }
+
+    let extensions_len = u16::from_be_bytes([body[pos], body[pos + 1]]) as usize;
+    pos += 2;
+    let extensions_end = pos + extensions_len;
+    if body.len() < extensions_end {
+        return false;
+    }
+
+    while pos + 4 <= extensions_end {
+        let extension_type = u16::from_be_bytes([body[pos], body[pos + 1]]);
+        let extension_len = u16::from_be_bytes([body[pos + 2], body[pos + 3]]) as usize;
+        let extension_body = pos + 4;
+        let next = extension_body + extension_len;
+        if next > extensions_end {
+            return false;
+        }
+
+        if extension_type == COOKIE_EXTENSION && extension_len > 2 {
+            let cookie_len = u16::from_be_bytes([body[extension_body], body[extension_body + 1]]);
+            if cookie_len == 0 {
+                return false;
+            }
+            body[extension_body..extension_body + 2]
+                .copy_from_slice(&(cookie_len - 1).to_be_bytes());
+            return true;
+        }
+
+        pos = next;
+    }
+
+    false
+}
+
+#[test]
+fn dtls13_client_rejects_hrr_cookie_extension_trailing_bytes() {
+    let _ = env_logger::try_init();
+
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+    let config = dtls13_config();
+    let now = Instant::now();
+
+    let mut client = Dtls::new_13(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_13(config, server_cert, now);
+    server.set_active(false);
+
+    client.handle_timeout(now).expect("client timeout");
+    let client_out = drain_outputs(&mut client);
+    assert!(!client_out.packets.is_empty(), "client should send CH1");
+    for packet in &client_out.packets {
+        server.handle_packet(packet).expect("server receives CH1");
+    }
+
+    server.handle_timeout(now).expect("server timeout");
+    let server_out = drain_outputs(&mut server);
+    let mut hrr = server_out
+        .packets
+        .into_iter()
+        .next()
+        .expect("server should emit HRR");
+    assert!(
+        shrink_dtls13_cookie_extension_inner_len(&mut hrr),
+        "fixture should contain a Cookie extension"
+    );
+
+    let err = client
+        .handle_packet(&hrr)
+        .expect_err("malformed HRR Cookie extension must be rejected");
+    assert!(matches!(
+        err,
+        dimpl::Error::ParseError(nom::error::ErrorKind::LengthValue)
+    ));
+
+    client
+        .handle_timeout(now)
+        .expect("client timeout after error");
+    let client_out = drain_outputs(&mut client);
+    assert!(
+        client_out.packets.is_empty(),
+        "client must not send CH2 after malformed HRR Cookie"
+    );
+}
+
+#[test]
+fn dtls13_server_rejects_clienthello_cookie_extension_trailing_bytes() {
+    let _ = env_logger::try_init();
+
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+    let config = dtls13_config();
+    let now = Instant::now();
+
+    let mut client = Dtls::new_13(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_13(config, server_cert, now);
+    server.set_active(false);
+
+    client.handle_timeout(now).expect("client timeout");
+    let client_out = drain_outputs(&mut client);
+    for packet in &client_out.packets {
+        server.handle_packet(packet).expect("server receives CH1");
+    }
+
+    server.handle_timeout(now).expect("server timeout");
+    let server_out = drain_outputs(&mut server);
+    let hrr = server_out
+        .packets
+        .first()
+        .expect("server should emit HRR")
+        .clone();
+    client
+        .handle_packet(&hrr)
+        .expect("client receives valid HRR");
+
+    client
+        .handle_timeout(now)
+        .expect("client timeout after HRR");
+    let client_out = drain_outputs(&mut client);
+    let mut ch2 = client_out
+        .packets
+        .into_iter()
+        .next()
+        .expect("client should emit CH2 with cookie");
+    assert!(
+        shrink_dtls13_cookie_extension_inner_len(&mut ch2),
+        "fixture should contain a Cookie extension"
+    );
+
+    let err = server
+        .handle_packet(&ch2)
+        .expect_err("malformed ClientHello Cookie extension must be rejected");
+    assert!(matches!(
+        err,
+        dimpl::Error::ParseError(nom::error::ErrorKind::LengthValue)
+    ));
+}


### PR DESCRIPTION
## Summary

- Add exact DTLS 1.3 Cookie extension-body parsing for `cookie<1..2^16-1>`.
- Apply it to client HRR Cookie handling and server returned-ClientHello Cookie handling.
- Add real-packet regressions for Cookie bodies with trailing bytes.

## Validation

- cargo fmt --check
- git diff --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings
- cargo test --no-default-features --features rust-crypto
- cargo clippy --no-default-features --features rust-crypto -- -D warnings
- cargo test --doc --features rcgen