### PR TITLE
dtls13: parse dtls12-only clienthellos for fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Parse DTLS 1.2-only ClientHellos for auto-sense fallback #129
   * Reject malformed DTLS 1.3 Cookie extension bodies #128
   * Reject oversized DTLS 1.2 CertificateRequest certificate authorities #127
   * Bound DTLS 1.3 ACK tracking during handshake replacement #120

--- a/src/dtls13/engine.rs
+++ b/src/dtls13/engine.rs
@@ -782,6 +782,22 @@ impl Engine {
         wanted: MessageType,
         defragment_buffer: &mut Buf,
     ) -> Result<Option<Handshake>, Error> {
+        self.next_handshake_with_options(wanted, defragment_buffer, false)
+    }
+
+    pub(crate) fn next_client_hello_for_auto_sense(
+        &mut self,
+        defragment_buffer: &mut Buf,
+    ) -> Result<Option<Handshake>, Error> {
+        self.next_handshake_with_options(MessageType::ClientHello, defragment_buffer, true)
+    }
+
+    fn next_handshake_with_options(
+        &mut self,
+        wanted: MessageType,
+        defragment_buffer: &mut Buf,
+        allow_unknown_client_hello_suites: bool,
+    ) -> Result<Option<Handshake>, Error> {
         if !self.has_complete_handshake(wanted) {
             return Ok(None);
         }
@@ -794,12 +810,21 @@ impl Engine {
             .flat_map(|r| r.handshakes().iter().map(move |h| (h, r.buffer())))
             .skip_while(|(h, _)| h.is_handled());
 
-        let handshake = Handshake::defragment(
-            iter,
-            defragment_buffer,
-            self.cipher_suite,
-            Some(&mut self.transcript),
-        )?;
+        let handshake = if allow_unknown_client_hello_suites {
+            Handshake::defragment_allow_unknown_client_hello_suites(
+                iter,
+                defragment_buffer,
+                self.cipher_suite,
+                Some(&mut self.transcript),
+            )
+        } else {
+            Handshake::defragment(
+                iter,
+                defragment_buffer,
+                self.cipher_suite,
+                Some(&mut self.transcript),
+            )
+        }?;
 
         Ok(Some(handshake))
     }

--- a/src/dtls13/message/client_hello.rs
+++ b/src/dtls13/message/client_hello.rs
@@ -7,7 +7,7 @@ use nom::number::complete::{be_u8, be_u16};
 use nom::{Err, IResult};
 
 use crate::buffer::Buf;
-use crate::util::many1;
+use crate::util::{many0, many1};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientHello {
@@ -41,15 +41,36 @@ impl ClientHello {
     }
 
     pub fn parse(input: &[u8], base_offset: usize) -> IResult<&[u8], ClientHello> {
+        Self::parse_with_options(input, base_offset, false)
+    }
+
+    pub(crate) fn parse_allow_unknown_suites(
+        input: &[u8],
+        base_offset: usize,
+    ) -> IResult<&[u8], ClientHello> {
+        Self::parse_with_options(input, base_offset, true)
+    }
+
+    fn parse_with_options(
+        input: &[u8],
+        base_offset: usize,
+        allow_unknown_suites: bool,
+    ) -> IResult<&[u8], ClientHello> {
         let original_input = input;
         let (input, legacy_version) = ProtocolVersion::parse(input)?;
         let (input, random) = Random::parse(input)?;
         let (input, legacy_session_id) = SessionId::parse(input)?;
         let (input, legacy_cookie) = Cookie::parse(input)?;
         let (input, cipher_suites_len) = be_u16(input)?;
+        if cipher_suites_len == 0 || cipher_suites_len % 2 != 0 {
+            return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+        }
         let (input, input_cipher) = take(cipher_suites_len)(input)?;
-        let (rest, cipher_suites) =
-            many1(Dtls13CipherSuite::parse, Dtls13CipherSuite::is_supported)(input_cipher)?;
+        let (rest, cipher_suites) = if allow_unknown_suites {
+            many0(Dtls13CipherSuite::parse, Dtls13CipherSuite::is_supported)(input_cipher)?
+        } else {
+            many1(Dtls13CipherSuite::parse, Dtls13CipherSuite::is_supported)(input_cipher)?
+        };
         if !rest.is_empty() {
             return Err(Err::Failure(Error::new(rest, ErrorKind::LengthValue)));
         }
@@ -213,6 +234,50 @@ mod tests {
         assert_eq!(parsed, client_hello);
 
         assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn dtls12_only_cipher_suites_parse_for_auto_detection() {
+        let mut message = MESSAGE.to_vec();
+        // DTLS 1.2 ECDHE_ECDSA AES-GCM suites are intentionally unknown to
+        // the DTLS 1.3 suite filter, but the ClientHello is structurally valid.
+        message[40..44].copy_from_slice(&[0xC0, 0x2B, 0xC0, 0x2C]);
+
+        let (rest, parsed) = ClientHello::parse_allow_unknown_suites(&message, 0).unwrap();
+
+        assert!(rest.is_empty());
+        assert!(parsed.cipher_suites.is_empty());
+    }
+
+    #[test]
+    fn dtls12_only_cipher_suites_are_rejected_by_normal_parse() {
+        let mut message = MESSAGE.to_vec();
+        message[40..44].copy_from_slice(&[0xC0, 0x2B, 0xC0, 0x2C]);
+
+        assert!(ClientHello::parse(&message, 0).is_err());
+    }
+
+    #[test]
+    fn empty_cipher_suites_is_malformed_in_both_modes() {
+        let mut message = Vec::new();
+        message.extend_from_slice(&MESSAGE[..38]);
+        message.extend_from_slice(&[0x00, 0x00]);
+        message.extend_from_slice(&MESSAGE[44..]);
+
+        assert!(ClientHello::parse(&message, 0).is_err());
+        assert!(ClientHello::parse_allow_unknown_suites(&message, 0).is_err());
+    }
+
+    #[test]
+    fn odd_cipher_suites_is_malformed_in_both_modes() {
+        let mut message = Vec::new();
+        message.extend_from_slice(&MESSAGE[..38]);
+        message.extend_from_slice(&[0x00, 0x03]);
+        message.extend_from_slice(&[0x13, 0x01, 0x13]);
+        message.extend_from_slice(&MESSAGE[44..]);
+
+        assert!(ClientHello::parse(&message, 0).is_err());
+        assert!(ClientHello::parse_allow_unknown_suites(&message, 0).is_err());
     }
 
     #[test]

--- a/src/dtls13/message/handshake.rs
+++ b/src/dtls13/message/handshake.rs
@@ -132,10 +132,29 @@ impl Handshake {
 
     #[allow(private_interfaces)]
     pub fn defragment<'b>(
+        iter: impl Iterator<Item = (&'b Handshake, &'b [u8])>,
+        buffer: &mut Buf,
+        cipher_suite: Option<Dtls13CipherSuite>,
+        transcript: Option<&mut Buf>,
+    ) -> Result<Handshake, crate::Error> {
+        Self::defragment_with_options(iter, buffer, cipher_suite, transcript, false)
+    }
+
+    pub(crate) fn defragment_allow_unknown_client_hello_suites<'b>(
+        iter: impl Iterator<Item = (&'b Handshake, &'b [u8])>,
+        buffer: &mut Buf,
+        cipher_suite: Option<Dtls13CipherSuite>,
+        transcript: Option<&mut Buf>,
+    ) -> Result<Handshake, crate::Error> {
+        Self::defragment_with_options(iter, buffer, cipher_suite, transcript, true)
+    }
+
+    fn defragment_with_options<'b>(
         mut iter: impl Iterator<Item = (&'b Handshake, &'b [u8])>,
         buffer: &mut Buf,
         cipher_suite: Option<Dtls13CipherSuite>,
         transcript: Option<&mut Buf>,
+        allow_unknown_client_hello_suites: bool,
     ) -> Result<Handshake, crate::Error> {
         buffer.clear();
 
@@ -189,7 +208,16 @@ impl Handshake {
             transcript.extend_from_slice(&buffer[..first_handshake.header.length as usize]);
         }
 
-        let (rest, body) = Body::parse(buffer, 0, first_handshake.header.msg_type, cipher_suite)?;
+        let (rest, body) = if allow_unknown_client_hello_suites {
+            Body::parse_allow_unknown_client_hello_suites(
+                buffer,
+                0,
+                first_handshake.header.msg_type,
+                cipher_suite,
+            )?
+        } else {
+            Body::parse(buffer, 0, first_handshake.header.msg_type, cipher_suite)?
+        };
 
         if !rest.is_empty() && first_handshake.header.msg_type == MessageType::Finished {
             debug!("Defragmentation failed. Body::parse() did not consume the entire buffer");
@@ -345,9 +373,32 @@ impl Body {
         m: MessageType,
         c: Option<Dtls13CipherSuite>,
     ) -> IResult<&[u8], Body> {
+        Self::parse_with_options(input, base_offset, m, c, false)
+    }
+
+    pub(crate) fn parse_allow_unknown_client_hello_suites(
+        input: &[u8],
+        base_offset: usize,
+        m: MessageType,
+        c: Option<Dtls13CipherSuite>,
+    ) -> IResult<&[u8], Body> {
+        Self::parse_with_options(input, base_offset, m, c, true)
+    }
+
+    fn parse_with_options(
+        input: &[u8],
+        base_offset: usize,
+        m: MessageType,
+        c: Option<Dtls13CipherSuite>,
+        allow_unknown_client_hello_suites: bool,
+    ) -> IResult<&[u8], Body> {
         match m {
             MessageType::ClientHello => {
-                let (input, client_hello) = ClientHello::parse(input, base_offset)?;
+                let (input, client_hello) = if allow_unknown_client_hello_suites {
+                    ClientHello::parse_allow_unknown_suites(input, base_offset)?
+                } else {
+                    ClientHello::parse(input, base_offset)?
+                };
                 Ok((input, Body::ClientHello(client_hello)))
             }
             MessageType::ServerHello => {

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -386,9 +386,15 @@ impl State {
         // arrives after HelloRetryRequest (no cookie → must discard).
         let transcript_len_before = server.engine.transcript.len();
 
-        let maybe = server
-            .engine
-            .next_handshake(MessageType::ClientHello, &mut server.defragment_buffer)?;
+        let maybe = if server.auto_mode {
+            server
+                .engine
+                .next_client_hello_for_auto_sense(&mut server.defragment_buffer)?
+        } else {
+            server
+                .engine
+                .next_handshake(MessageType::ClientHello, &mut server.defragment_buffer)?
+        };
 
         let Some(handshake) = maybe else {
             return Ok(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,12 +317,7 @@ fn client_hello_handshake(packet: &[u8]) -> Option<&[u8]> {
     Some(record_body)
 }
 
-/// Lightweight structural check: does this packet look like a ClientHello?
-///
-/// Used by the auto-sense server to gate the DTLS 1.2 fallback on parse
-/// errors. A packet that fails to parse in the DTLS 1.3 engine should
-/// only trigger a downgrade if it at least claims to be a ClientHello —
-/// otherwise random/garbage traffic could force fallback.
+/// Lightweight structural test helper: does this packet look like a ClientHello?
 ///
 /// In addition to the record/handshake header check from
 /// [`client_hello_handshake`], this validates wire-format integrity of
@@ -332,6 +327,7 @@ fn client_hello_handshake(packet: &[u8]) -> Option<&[u8]> {
 /// minimum a real DTLS 1.2 ClientHello can carry. A header-only fake
 /// or a CH whose declared length cannot fit a valid 1.2 body fails the
 /// check.
+#[cfg(all(test, feature = "rcgen"))]
 fn looks_like_client_hello(packet: &[u8]) -> bool {
     let Some(record_body) = client_hello_handshake(packet) else {
         return false;
@@ -349,12 +345,8 @@ fn looks_like_client_hello(packet: &[u8]) -> bool {
         | ((record_body[10] as usize) << 8)
         | record_body[11] as usize;
 
-    // Only the first fragment (offset 0) is allowed to trigger fallback.
-    // A non-first fragment arriving alone could be a spoofed packet
-    // designed to force a downgrade; a real fragmented CH always sends
-    // a fragment with offset 0 too, and the clean Dtls12Fallback path
-    // (driven by supported_versions, not by this gate) handles real
-    // fragmented 1.2 CHs once reassembly completes.
+    // A non-first fragment alone is not enough to prove that the packet
+    // carries the start of a ClientHello body.
     if frag_off != 0 {
         return false;
     }
@@ -618,25 +610,11 @@ impl Dtls {
         match self.inner.as_mut().unwrap() {
             Inner::ClientPending(_) => self.handle_pending_auto_client(packet),
             Inner::Server13(server) if server.is_auto_mode() => {
-                // Run the structural check unconditionally so the time
-                // spent here does not leak which error branch the parser
-                // took — same cost whether handle_packet returns Ok,
-                // Dtls12Fallback, ParseError, or anything else.
-                let is_ch_shaped = looks_like_client_hello(packet);
                 match server.handle_packet(packet) {
                     Ok(()) => Ok(()),
                     Err(Error::Dtls12Fallback) => {
                         // The 1.3 engine cleanly rejected a ClientHello
                         // that did not offer DTLS 1.3 in supported_versions.
-                        self.handle_pending_auto_server()
-                    }
-                    Err(Error::ParseError(_) | Error::ParseIncomplete) if is_ch_shaped => {
-                        // The packet is structurally a ClientHello but the
-                        // 1.3 parser couldn't handle it — fall back to 1.2,
-                        // which has a more permissive parser. Random/garbage
-                        // traffic that happens to error is not caught here,
-                        // so an off-path attacker cannot force a downgrade
-                        // by spraying malformed packets.
                         self.handle_pending_auto_server()
                     }
                     Err(e) => Err(e),
@@ -1287,15 +1265,15 @@ mod test {
     }
 
     /// CH-shaped body whose `cipher_suites_length` exceeds the bytes that
-    /// follow it — the DTLS 1.3 body parser will error on this. Used to
-    /// drive the auto-server into the gated ParseError fallback path.
+    /// follow it. The structural gate accepts this as ClientHello-shaped, but
+    /// the parser must reject it without forcing auto-sense fallback.
     fn ch_shaped_malformed_body() -> Vec<u8> {
         let mut body = Vec::new();
         body.extend_from_slice(&[0xFE, 0xFD]); // version
         body.extend_from_slice(&[0u8; 32]); // random
         body.push(0); // session_id_length = 0
         body.push(0); // cookie_length = 0
-        body.extend_from_slice(&[0xFF, 0xFF]); // cipher_suites_length = 65535 — bogus
+        body.extend_from_slice(&[0x00, 0x04]); // cipher_suites_length exceeds available suites
         body.extend_from_slice(&[0xC0, 0x2B]); // 2 bytes that pretend to be a suite
         body.push(1); // compression_methods_length = 1
         body.push(0); // null compression
@@ -1303,13 +1281,7 @@ mod test {
     }
 
     #[test]
-    fn auto_server_falls_back_on_ch_shaped_malformed_packet() {
-        // Documents the intentional behavior of the gated fallback: a
-        // packet that is structurally a ClientHello (passes
-        // `looks_like_client_hello`) but whose body cannot be parsed by
-        // the DTLS 1.3 engine should still flip the auto-sense server
-        // into DTLS 1.2 mode. (Random non-CH garbage does not — see
-        // `auto_server_drops_garbage_without_falling_back`.)
+    fn auto_server_rejects_ch_shaped_malformed_packet_without_fallback() {
         let body = ch_shaped_malformed_body();
         let len = body.len() as u32;
         let hs = make_handshake(0x01, len, 0, len, &body);
@@ -1320,15 +1292,18 @@ mod test {
         );
 
         let mut dtls = new_instance_auto();
-        // Server12 will also fail to parse this packet on replay, so
-        // ignore the result of handle_packet — we only care about which
-        // inner state we ended up in.
-        let _ = dtls.handle_packet(&pkt);
-        let fell_back = matches!(dtls.inner, Some(Inner::Server12(_)));
+        let err = dtls
+            .handle_packet(&pkt)
+            .expect_err("malformed ClientHello-shaped packet must not force fallback");
+
         assert!(
-            fell_back,
-            "auto-sense server must fall back to DTLS 1.2 on a CH-shaped malformed packet"
+            matches!(err, Error::ParseIncomplete | Error::ParseError(_)),
+            "expected parser error, got {err:?}"
         );
+        assert!(matches!(
+            dtls.inner,
+            Some(Inner::Server13(ref server)) if server.is_auto_mode()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Allow structurally valid DTLS 1.2-only ClientHellos to parse far enough for auto-sense version detection.
- Keep empty or odd-length cipher suite vectors malformed.
- Stop treating malformed ClientHello-shaped parse errors as an automatic DTLS 1.2 fallback trigger.

## Validation

- cargo fmt --check
- git diff --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings
- cargo test --no-default-features --features rust-crypto
- cargo clippy --no-default-features --features rust-crypto -- -D warnings
- cargo test --doc --features rcgen