### PR TITLE
dtls13: reject malformed KeyUpdate bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reject malformed DTLS 1.3 KeyUpdate bodies #131
   * Parse DTLS 1.2-only ClientHellos for auto-sense fallback #129
   * Reject malformed DTLS 1.3 Cookie extension bodies #128
   * Reject oversized DTLS 1.2 CertificateRequest certificate authorities #127

--- a/src/dtls13/message/handshake.rs
+++ b/src/dtls13/message/handshake.rs
@@ -429,6 +429,9 @@ impl Body {
             }
             MessageType::KeyUpdate => {
                 let (input, byte) = be_u8(input)?;
+                if !input.is_empty() {
+                    return Err(Err::Failure(Error::new(input, ErrorKind::LengthValue)));
+                }
                 let request = KeyUpdateRequest::from_u8(byte)
                     .ok_or_else(|| Err::Failure(Error::new(input, ErrorKind::Fail)))?;
                 Ok((input, Body::KeyUpdate(request)))
@@ -565,5 +568,31 @@ mod tests {
         assert_eq!(parsed, handshake);
 
         assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn key_update_body_rejects_trailing_bytes() {
+        let source = [KeyUpdateRequest::UpdateRequested.as_u8(), 0];
+        let handshake = Handshake::new(
+            MessageType::KeyUpdate,
+            source.len() as u32,
+            0,
+            0,
+            source.len() as u32,
+            Body::Fragment(0..source.len()),
+        );
+
+        let mut buffer = Buf::new();
+        let result = Handshake::defragment(
+            std::iter::once((&handshake, source.as_slice())),
+            &mut buffer,
+            None,
+            None,
+        );
+
+        assert!(
+            result.is_err(),
+            "KeyUpdate bodies with trailing bytes must be rejected"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Reject DTLS 1.3 KeyUpdate bodies with trailing bytes after the request byte.
- Keep valid one-byte KeyUpdate bodies unchanged.
- Add a defragmentation regression for malformed KeyUpdate bodies.

## Validation

- cargo fmt --check
- git diff --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings
- cargo test --no-default-features --features rust-crypto
- cargo clippy --no-default-features --features rust-crypto -- -D warnings
- cargo test --doc --features rcgen