### PR TITLE
dtls13: stabilize plaintext ACK retransmit test

### DIFF
--- a/tests/dtls13/edge.rs
+++ b/tests/dtls13/edge.rs
@@ -837,7 +837,9 @@ fn dtls13_post_encryption_plaintext_ack_does_not_stop_retransmit() {
         .handle_packet(&dtls13_ack_record_for_records(0x200, &acked_records))
         .expect("post-encryption plaintext ACK should be ignored");
 
-    now += Duration::from_millis(150);
+    // The flight timer jitter is absolute (+/-250 ms), so wait past the
+    // maximum possible jitter for a 100 ms start RTO.
+    now += Duration::from_millis(400);
     server.handle_timeout(now).expect("server timeout");
     let retransmit = collect_packets(&mut server);
     assert!(


### PR DESCRIPTION
## Summary

- Wait past the maximum first-flight jitter in the plaintext ACK retransmit regression.
- Keep production ACK filtering and retransmit behavior unchanged.
- Preserve the assertion that a forged plaintext ACK must not stop server flight retransmission.

## Validation

- cargo fmt --check
- git diff --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings
- cargo test --no-default-features --features rust-crypto
- cargo clippy --no-default-features --features rust-crypto -- -D warnings
- cargo test --doc --features rcgen