### PR TITLE
dtls13: reject malformed ClientHello extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Reject malformed DTLS 1.3 ClientHello extension vectors #133
   * Parse DTLS 1.2-only ClientHellos for auto-sense fallback #129
   * Reject malformed DTLS 1.3 Cookie extension bodies #128
   * Reject oversized DTLS 1.2 CertificateRequest certificate authorities #127

--- a/src/dtls13/message/client_hello.rs
+++ b/src/dtls13/message/client_hello.rs
@@ -114,11 +114,10 @@ impl ClientHello {
         let original_input = input;
         let (remaining, extensions_len) = be_u16(input)?;
 
-        if extensions_len == 0 {
-            return Ok((remaining, extensions));
-        }
-
         let (remaining, extensions_data) = take(extensions_len)(remaining)?;
+        if !remaining.is_empty() {
+            return Err(Err::Failure(Error::new(remaining, ErrorKind::LengthValue)));
+        }
 
         let consumed = extensions_data.as_ptr() as usize - original_input.as_ptr() as usize;
         let data_base_offset = base_offset + consumed;
@@ -355,5 +354,32 @@ mod tests {
                 "duplicate supported extensions should fail with LengthValue"
             );
         }
+    }
+
+    #[test]
+    fn zero_length_extension_vector_rejects_trailing_bytes() {
+        let mut message = MESSAGE.to_vec();
+        message.extend_from_slice(&0u16.to_be_bytes());
+        message.extend_from_slice(&ExtensionType::Cookie.as_u16().to_be_bytes());
+        message.extend_from_slice(&0u16.to_be_bytes());
+
+        assert!(
+            ClientHello::parse(&message, 0).is_err(),
+            "extension vector length 0 must consume the remaining ClientHello body"
+        );
+    }
+
+    #[test]
+    fn underdeclared_extension_vector_rejects_trailing_bytes() {
+        let mut message = MESSAGE.to_vec();
+        message.extend_from_slice(&4u16.to_be_bytes());
+        message.extend_from_slice(&ExtensionType::Cookie.as_u16().to_be_bytes());
+        message.extend_from_slice(&0u16.to_be_bytes());
+        message.push(0);
+
+        assert!(
+            ClientHello::parse(&message, 0).is_err(),
+            "declared extension vector length must consume the remaining ClientHello body"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Reject DTLS 1.3 ClientHello extension vectors that do not consume the remaining ClientHello body.
- Preserve ClientHellos with no extension vector.
- Add regressions for zero-length and underdeclared extension vectors with trailing bytes.

## Validation

- cargo fmt --check
- git diff --check
- cargo test --all-targets --features rcgen
- cargo clippy --all-targets --features rcgen -- -D warnings
- cargo test --no-default-features --features rust-crypto
- cargo clippy --no-default-features --features rust-crypto -- -D warnings
- cargo test --doc --features rcgen