### PR TITLE
dtls: filter pre-ClientHello queue poison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Filter pre-ClientHello queue poison records #140
   * Represent DTLS wire-code identifiers as compact newtypes (breaking) #137
   * Make public errors structured and fatal-only (breaking) #134
 

--- a/src/dtls12/engine.rs
+++ b/src/dtls12/engine.rs
@@ -229,22 +229,34 @@ impl Engine {
         Ok(())
     }
 
-    /// Insert a parsed datagram into the receive queue.
-    fn insert_incoming(&mut self, incoming: Incoming) -> Result<(), Error> {
-        // Capacity guard before iterating records.
-        if self.queue_rx.len() >= self.config.max_queue_rx() {
-            warn!(
-                "Receive queue full (max {}): {:?}",
-                self.config.max_queue_rx(),
-                self.queue_rx
-            );
-            return Err(Error::ReceiveQueueFull);
+    pub(crate) fn parse_packet_filtering_records(
+        &mut self,
+        packet: &[u8],
+        keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<(), InternalError> {
+        let cs = self.cipher_suite;
+        let incoming = Incoming::parse_packet_filtering_records(packet, self, cs, keep_record)?;
+        if let Some(incoming) = incoming {
+            self.insert_incoming(incoming)?;
         }
 
+        Ok(())
+    }
+
+    /// Insert a parsed datagram into the receive queue.
+    fn insert_incoming(&mut self, incoming: Incoming) -> Result<(), Error> {
         // Dispatch to specialized handlers
         if incoming.first().first_handshake().is_some() {
             self.insert_incoming_handshake(incoming)
         } else {
+            if self.queue_rx.len() >= self.config.max_queue_rx() {
+                warn!(
+                    "Receive queue full (max {}): {:?}",
+                    self.config.max_queue_rx(),
+                    self.queue_rx
+                );
+                return Err(Error::ReceiveQueueFull);
+            }
             self.insert_incoming_non_handshake(incoming)
         }
     }
@@ -307,6 +319,14 @@ impl Engine {
 
         match search_result {
             Err(index) => {
+                if self.queue_rx.len() >= self.config.max_queue_rx() {
+                    warn!(
+                        "Receive queue full (max {}): {:?}",
+                        self.config.max_queue_rx(),
+                        self.queue_rx
+                    );
+                    return Err(Error::ReceiveQueueFull);
+                }
                 // Insert in order of handshake key
                 self.queue_rx.insert(index, incoming);
             }
@@ -588,6 +608,10 @@ impl Engine {
 
     pub fn has_complete_handshake(&mut self, wanted: MessageType) -> bool {
         self.has_complete_handshake_with_seq(wanted, self.peer_handshake_seq_no)
+    }
+
+    pub(crate) fn expected_peer_handshake_seq_no(&self) -> u16 {
+        self.peer_handshake_seq_no
     }
 
     fn has_complete_handshake_with_seq(&mut self, wanted: MessageType, expected_seq: u16) -> bool {

--- a/src/dtls12/incoming.rs
+++ b/src/dtls12/incoming.rs
@@ -58,6 +58,23 @@ impl Incoming {
 
         Ok(Some(Incoming { records }))
     }
+
+    pub(crate) fn parse_packet_filtering_records(
+        packet: &[u8],
+        decrypt: &mut dyn RecordHandler,
+        cs: Option<Dtls12CipherSuite>,
+        keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<Option<Self>, InternalError> {
+        let records = Records::parse_filtering_records(packet, decrypt, cs, keep_record)?;
+
+        if records.records.is_empty() {
+            return Ok(None);
+        }
+
+        let records = Box::new(records);
+
+        Ok(Some(Incoming { records }))
+    }
 }
 
 /// A number of records parsed from a single UDP packet.
@@ -68,11 +85,21 @@ pub struct Records {
 
 impl Records {
     pub fn parse(
-        mut packet: &[u8],
+        packet: &[u8],
         decrypt: &mut dyn RecordHandler,
         cs: Option<Dtls12CipherSuite>,
     ) -> Result<Records, InternalError> {
+        Self::parse_filtering_records(packet, decrypt, cs, |_| true)
+    }
+
+    fn parse_filtering_records(
+        mut packet: &[u8],
+        decrypt: &mut dyn RecordHandler,
+        cs: Option<Dtls12CipherSuite>,
+        mut keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<Records, InternalError> {
         let mut parsed_records: ArrayVec<Record, 8> = ArrayVec::new();
+        let mut parsed_record_count = 0usize;
 
         // Find record boundaries and copy each record ONCE from the packet
         while !packet.is_empty() {
@@ -93,8 +120,17 @@ impl Records {
             match Record::parse(record_slice, decrypt, cs) {
                 Ok(record) => {
                     if let Some(record) = record {
-                        if parsed_records.try_push(record).is_err() {
+                        if parsed_record_count >= parsed_records.capacity() {
                             return Err(InternalError::too_many_records());
+                        }
+                        parsed_record_count += 1;
+
+                        if !keep_record(&record) {
+                            trace!("Discarding filtered rec");
+                        } else {
+                            parsed_records
+                                .try_push(record)
+                                .expect("parsed record count is capacity-checked");
                         }
                     } else {
                         trace!("Discarding replayed rec");

--- a/src/dtls12/server.rs
+++ b/src/dtls12/server.rs
@@ -189,11 +189,25 @@ impl Server {
     }
 
     pub fn handle_packet(&mut self, packet: &[u8]) -> Result<(), Error> {
-        match self
-            .engine
-            .parse_packet(packet)
-            .and_then(|_| self.make_progress())
-        {
+        let result = if self.state == State::AwaitClientHello {
+            let expected_seq = self.engine.expected_peer_handshake_seq_no();
+            self.engine
+                .parse_packet_filtering_records(packet, |record| {
+                    record.record().sequence.epoch == 0
+                        && (record.record().content_type == ContentType::Alert
+                            || (record.record().content_type == ContentType::Handshake
+                                && record.first_handshake().is_some_and(|h| {
+                                    h.header.msg_type == MessageType::ClientHello
+                                        && (h.header.message_seq == expected_seq
+                                            || h.header.message_seq.saturating_add(1)
+                                                == expected_seq)
+                                })))
+                })
+        } else {
+            self.engine.parse_packet(packet)
+        };
+
+        match result.and_then(|_| self.make_progress()) {
             Ok(()) => Ok(()),
             Err(e) => e.into_public_error().map_or(Ok(()), Err),
         }

--- a/src/dtls13/engine.rs
+++ b/src/dtls13/engine.rs
@@ -55,6 +55,9 @@ pub struct Engine {
     /// Queue of incoming packets.
     queue_rx: QueueRx,
 
+    /// Last accepted pre-ClientHello packet after parser-side filtering.
+    last_parse_queueable_packet: Option<Buf>,
+
     /// Queue of outgoing packets.
     queue_tx: QueueTx,
 
@@ -220,6 +223,7 @@ impl Engine {
             buffers_free: BufferPool::default(),
             sequence_epoch_0: Sequence::new(0),
             queue_rx: QueueRx::new(),
+            last_parse_queueable_packet: None,
             queue_tx: QueueTx::new(),
             cipher_suite: None,
             hs_send_keys: None,
@@ -332,6 +336,7 @@ impl Engine {
     pub fn parse_packet(&mut self, packet: &[u8]) -> Result<(), InternalError> {
         let cs = self.cipher_suite;
         let incoming = Incoming::parse_packet(packet, self, cs)?;
+        self.last_parse_queueable_packet = None;
         if let Some(incoming) = incoming {
             self.insert_incoming(incoming)?;
         }
@@ -339,19 +344,46 @@ impl Engine {
         Ok(())
     }
 
-    fn insert_incoming(&mut self, incoming: Incoming) -> Result<(), Error> {
-        if self.queue_rx.len() >= self.config.max_queue_rx() {
-            warn!(
-                "Receive queue full (max {}): {:?}",
-                self.config.max_queue_rx(),
-                self.queue_rx
-            );
-            return Err(Error::ReceiveQueueFull);
+    pub(crate) fn parse_packet_filtering_records(
+        &mut self,
+        packet: &[u8],
+        retain_queueable_packet: bool,
+        keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<(), InternalError> {
+        let cs = self.cipher_suite;
+        let incoming = Incoming::parse_packet_filtering_records(packet, self, cs, keep_record)?;
+        self.last_parse_queueable_packet = None;
+        if let Some(incoming) = incoming {
+            let queueable_packet = (retain_queueable_packet
+                && incoming.first().first_handshake().is_some())
+            .then(|| incoming.to_datagram_buf());
+            self.insert_incoming(incoming)?;
+            self.last_parse_queueable_packet = queueable_packet;
         }
 
+        Ok(())
+    }
+
+    pub(crate) fn take_last_parse_queueable_packet(&mut self) -> Option<Buf> {
+        self.last_parse_queueable_packet.take()
+    }
+
+    pub(crate) fn clear_last_parse_queueable_packet(&mut self) {
+        self.last_parse_queueable_packet = None;
+    }
+
+    fn insert_incoming(&mut self, incoming: Incoming) -> Result<(), Error> {
         if incoming.first().first_handshake().is_some() {
             self.insert_incoming_handshake(incoming)
         } else {
+            if self.queue_rx.len() >= self.config.max_queue_rx() {
+                warn!(
+                    "Receive queue full (max {}): {:?}",
+                    self.config.max_queue_rx(),
+                    self.queue_rx
+                );
+                return Err(Error::ReceiveQueueFull);
+            }
             self.insert_incoming_non_handshake(incoming)
         }
     }
@@ -406,6 +438,14 @@ impl Engine {
 
         match search_result {
             Err(index) => {
+                if self.queue_rx.len() >= self.config.max_queue_rx() {
+                    warn!(
+                        "Receive queue full (max {}): {:?}",
+                        self.config.max_queue_rx(),
+                        self.queue_rx
+                    );
+                    return Err(Error::ReceiveQueueFull);
+                }
                 // Track received record numbers for ACK generation
                 for record in incoming.records().iter() {
                     let seq = record.record().sequence;
@@ -724,6 +764,10 @@ impl Engine {
 
     pub fn has_complete_handshake(&mut self, wanted: MessageType) -> bool {
         self.has_complete_handshake_with_seq(wanted, self.peer_handshake_seq_no)
+    }
+
+    pub(crate) fn expected_peer_handshake_seq_no(&self) -> u16 {
+        self.peer_handshake_seq_no
     }
 
     fn has_complete_handshake_with_seq(&mut self, wanted: MessageType, expected_seq: u16) -> bool {

--- a/src/dtls13/incoming.rs
+++ b/src/dtls13/incoming.rs
@@ -29,6 +29,14 @@ impl Incoming {
     pub fn into_records(self) -> impl Iterator<Item = Record> {
         self.records.records.into_iter()
     }
+
+    pub(crate) fn to_datagram_buf(&self) -> Buf {
+        let mut packet = Buf::new();
+        for record in &self.records.records {
+            packet.extend_from_slice(record.buffer());
+        }
+        packet
+    }
 }
 
 impl Incoming {
@@ -57,6 +65,23 @@ impl Incoming {
 
         Ok(Some(Incoming { records }))
     }
+
+    pub(crate) fn parse_packet_filtering_records(
+        packet: &[u8],
+        decrypt: &mut dyn RecordHandler,
+        cs: Option<Dtls13CipherSuite>,
+        keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<Option<Self>, InternalError> {
+        let records = Records::parse_filtering_records(packet, decrypt, cs, keep_record)?;
+
+        if records.records.is_empty() {
+            return Ok(None);
+        }
+
+        let records = Box::new(records);
+
+        Ok(Some(Incoming { records }))
+    }
 }
 
 /// A number of records parsed from a single UDP packet.
@@ -67,11 +92,21 @@ pub struct Records {
 
 impl Records {
     pub fn parse(
-        mut packet: &[u8],
+        packet: &[u8],
         decrypt: &mut dyn RecordHandler,
         cs: Option<Dtls13CipherSuite>,
     ) -> Result<Records, InternalError> {
+        Self::parse_filtering_records(packet, decrypt, cs, |_| true)
+    }
+
+    fn parse_filtering_records(
+        mut packet: &[u8],
+        decrypt: &mut dyn RecordHandler,
+        cs: Option<Dtls13CipherSuite>,
+        mut keep_record: impl FnMut(&Record) -> bool,
+    ) -> Result<Records, InternalError> {
         let mut parsed_records: ArrayVec<Record, 16> = ArrayVec::new();
+        let mut parsed_record_count = 0usize;
 
         // Find record boundaries and copy each record ONCE from the packet
         while !packet.is_empty() {
@@ -132,8 +167,17 @@ impl Records {
             match Record::parse(record_slice, decrypt, cs) {
                 Ok(record) => {
                     if let Some(record) = record {
-                        if parsed_records.try_push(record).is_err() {
+                        if parsed_record_count >= parsed_records.capacity() {
                             return Err(InternalError::too_many_records());
+                        }
+                        parsed_record_count += 1;
+
+                        if !keep_record(&record) {
+                            trace!("Discarding filtered rec");
+                        } else {
+                            parsed_records
+                                .try_push(record)
+                                .expect("parsed record count is capacity-checked");
                         }
                     } else {
                         trace!("Discarding replayed rec");

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -47,6 +47,7 @@ use crate::dtls13::message::CompressionMethod;
 use crate::dtls13::message::ContentType;
 use crate::dtls13::message::DistinguishedName;
 use crate::dtls13::message::Dtls13CipherSuite;
+use crate::dtls13::message::Dtls13Record;
 use crate::dtls13::message::Extension;
 use crate::dtls13::message::ExtensionType;
 use crate::dtls13::message::KeyShareClientHello;
@@ -238,21 +239,63 @@ impl Server {
     }
 
     pub fn handle_packet(&mut self, packet: &[u8]) -> Result<(), Error> {
-        // In auto-sense mode, buffer raw packets while still waiting for
-        // the ClientHello so they can be replayed to Server12 on fallback.
-        if self.auto_mode && self.state == State::AwaitClientHello {
-            // Cap buffered fragments to prevent unbounded growth from malicious traffic
-            if self.retained_hello.len() >= MAX_RETAINED_CLIENT_HELLO {
+        let awaiting_client_hello = self.state == State::AwaitClientHello;
+        let mut queueable_packet = None;
+
+        if awaiting_client_hello {
+            if self.auto_mode && self.retained_hello.len() >= MAX_RETAINED_CLIENT_HELLO {
                 return Err(Error::TooManyClientHelloFragments);
             }
-            self.retained_hello.push_back(packet.to_buf());
+
+            let expected_seq = self.engine.expected_peer_handshake_seq_no();
+            match self
+                .engine
+                .parse_packet_filtering_records(packet, self.auto_mode, |record| {
+                    !Dtls13Record::is_ciphertext_header(record.buffer()[0])
+                        && (record.record().content_type == ContentType::Alert
+                            || (record.record().content_type == ContentType::Handshake
+                                && record.first_handshake().is_some_and(|h| {
+                                    h.header.msg_type == MessageType::ClientHello
+                                        && (h.header.message_seq == expected_seq
+                                            || h.header.message_seq.saturating_add(1)
+                                                == expected_seq)
+                                })))
+                }) {
+                Ok(()) => {
+                    if self.auto_mode {
+                        queueable_packet = self.engine.take_last_parse_queueable_packet();
+                    } else {
+                        self.engine.clear_last_parse_queueable_packet();
+                    }
+                }
+                Err(e) => {
+                    self.engine.clear_last_parse_queueable_packet();
+                    if let Some(err) = e.into_public_error() {
+                        return Err(err);
+                    }
+                    return Ok(());
+                }
+            }
+        } else {
+            match self.engine.parse_packet(packet) {
+                Ok(()) => {}
+                Err(e) => {
+                    self.engine.clear_last_parse_queueable_packet();
+                    if let Some(err) = e.into_public_error() {
+                        return Err(err);
+                    }
+                    return Ok(());
+                }
+            }
         }
 
-        match self
-            .engine
-            .parse_packet(packet)
-            .and_then(|_| self.make_progress())
-        {
+        if self.auto_mode && awaiting_client_hello {
+            if let Some(packet) = queueable_packet {
+                self.retained_hello.push_back(packet);
+            }
+        }
+
+        match self.make_progress() {
             Ok(()) => {}
             Err(e) => {
                 if let Some(err) = e.into_public_error() {

--- a/tests/auto/server_fallback.rs
+++ b/tests/auto/server_fallback.rs
@@ -53,6 +53,14 @@ fn run_handshake(
     )
 }
 
+fn dtls13_future_epoch_ciphertext(seq: u16) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(0x2E); // fixed bits, S=1, L=1, epoch_bits=2
+    out.extend_from_slice(&seq.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes()); // empty ciphertext
+    out
+}
+
 // ============================================================================
 // Auto server + explicit DTLS 1.3 client → DTLS 1.3 (no fallback)
 // ============================================================================
@@ -132,6 +140,39 @@ fn auto_server_protocol_version_pending() {
 
     assert!(cc, "Client should connect after pending protocol check");
     assert!(sc, "Server should connect after pending protocol check");
+    assert_eq!(cv, Some(ProtocolVersion::DTLS1_2));
+    assert_eq!(sv, Some(ProtocolVersion::DTLS1_2));
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn auto_server_fallback_ignores_prehandshake_dtls13_ciphertext_poison() {
+    use dimpl::certificate::generate_self_signed_certificate;
+
+    let _ = env_logger::try_init();
+
+    let client_cert = generate_self_signed_certificate().unwrap();
+    let server_cert = generate_self_signed_certificate().unwrap();
+    let config = Arc::new(
+        Config::builder()
+            .max_queue_rx(1)
+            .build()
+            .expect("build config"),
+    );
+
+    let mut client = Dtls::new_12(Arc::clone(&config), client_cert, Instant::now());
+    client.set_active(true);
+
+    let mut server = Dtls::new_auto(config, server_cert, Instant::now());
+
+    server
+        .handle_packet(&dtls13_future_epoch_ciphertext(0))
+        .expect("pre-ClientHello DTLS 1.3 ciphertext should not poison fallback");
+
+    let (cc, sc, cv, sv) = run_handshake(&mut client, &mut server);
+
+    assert!(cc, "Client should connect");
+    assert!(sc, "Server should connect");
     assert_eq!(cv, Some(ProtocolVersion::DTLS1_2));
     assert_eq!(sv, Some(ProtocolVersion::DTLS1_2));
 }

--- a/tests/dtls12/edge.rs
+++ b/tests/dtls12/edge.rs
@@ -62,6 +62,89 @@ fn dtls12_min_protected_fragment_len(suite: Dtls12CipherSuite) -> usize {
     }
 }
 
+fn dtls12_change_cipher_spec_record(seq: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(20); // ChangeCipherSpec
+    out.extend_from_slice(&[0xFE, 0xFD]); // DTLS 1.2
+    out.extend_from_slice(&0u16.to_be_bytes()); // epoch 0
+    out.extend_from_slice(&seq.to_be_bytes()[2..]); // u48 sequence number
+    out.extend_from_slice(&1u16.to_be_bytes()); // payload length
+    out.push(1); // change_cipher_spec
+    out
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls12_client_server_with_max_queue(max_queue_rx: usize) -> (Dtls, Dtls, Instant) {
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+    let config = Arc::new(
+        Config::builder()
+            .max_queue_rx(max_queue_rx)
+            .build()
+            .expect("build config"),
+    );
+
+    let now = Instant::now();
+    let mut client = Dtls::new_12(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_12(config, server_cert, now);
+    server.set_active(false);
+
+    (client, server, now)
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls12_client_hello(client: &mut Dtls, now: Instant) -> Vec<Vec<u8>> {
+    client.handle_timeout(now).expect("client timeout");
+    let packets = collect_packets(client);
+    assert!(!packets.is_empty(), "client should emit ClientHello");
+    packets
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls12_server_responds_to_client_hello(client: &mut Dtls, server: &mut Dtls, now: Instant) {
+    let packets = dtls12_client_hello(client, now);
+    for packet in &packets {
+        server
+            .handle_packet(packet)
+            .expect("ClientHello should not be blocked");
+    }
+
+    server.handle_timeout(now).expect("server timeout");
+    let server_out = collect_packets(server);
+    assert!(
+        !server_out.is_empty(),
+        "server should respond after ClientHello"
+    );
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_prehandshake_future_epoch_records_do_not_block_client_hello() {
+    let _ = env_logger::try_init();
+    let (mut client, mut server, now) = dtls12_client_server_with_max_queue(1);
+
+    server
+        .handle_packet(&dtls12_epoch1_record(0, 0))
+        .expect("pre-handshake future-epoch record should be tolerated");
+
+    dtls12_server_responds_to_client_hello(&mut client, &mut server, now);
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls12_prehandshake_plaintext_non_client_hello_records_do_not_block_client_hello() {
+    let _ = env_logger::try_init();
+    let (mut client, mut server, now) = dtls12_client_server_with_max_queue(1);
+
+    server
+        .handle_packet(&dtls12_change_cipher_spec_record(0))
+        .expect("pre-handshake CCS should not occupy receive queue");
+
+    dtls12_server_responds_to_client_hello(&mut client, &mut server, now);
+}
+
 #[test]
 #[cfg(feature = "rcgen")]
 fn dtls12_malformed_datagram_is_discarded_without_processing_alerts() {

--- a/tests/dtls13/edge.rs
+++ b/tests/dtls13/edge.rs
@@ -50,6 +50,86 @@ fn dtls13_ack_record_for_records(seq: u64, records: &[(u64, u64)]) -> Vec<u8> {
     out
 }
 
+fn dtls13_future_epoch_ciphertext(seq: u16) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(0x2E); // fixed bits, S=1, L=1, epoch_bits=2
+    out.extend_from_slice(&seq.to_be_bytes());
+    out.extend_from_slice(&0u16.to_be_bytes()); // empty ciphertext
+    out
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls13_client_server_with_max_queue(max_queue_rx: usize) -> (Dtls, Dtls, Instant) {
+    let client_cert = generate_self_signed_certificate().expect("gen client cert");
+    let server_cert = generate_self_signed_certificate().expect("gen server cert");
+    let config = Arc::new(
+        Config::builder()
+            .max_queue_rx(max_queue_rx)
+            .build()
+            .expect("build config"),
+    );
+
+    let now = Instant::now();
+    let mut client = Dtls::new_13(Arc::clone(&config), client_cert, now);
+    client.set_active(true);
+
+    let mut server = Dtls::new_13(config, server_cert, now);
+    server.set_active(false);
+
+    (client, server, now)
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls13_client_hello(client: &mut Dtls, now: Instant) -> Vec<Vec<u8>> {
+    client.handle_timeout(now).expect("client timeout");
+    let packets = collect_packets(client);
+    assert!(!packets.is_empty(), "client should emit ClientHello");
+    packets
+}
+
+#[cfg(feature = "rcgen")]
+fn dtls13_server_responds_to_client_hello(client: &mut Dtls, server: &mut Dtls, now: Instant) {
+    let packets = dtls13_client_hello(client, now);
+    for packet in &packets {
+        server
+            .handle_packet(packet)
+            .expect("ClientHello should not be blocked");
+    }
+
+    server.handle_timeout(now).expect("server timeout");
+    let server_out = collect_packets(server);
+    assert!(
+        !server_out.is_empty(),
+        "server should respond after ClientHello"
+    );
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls13_prehandshake_future_epoch_records_do_not_block_client_hello() {
+    let _ = env_logger::try_init();
+    let (mut client, mut server, now) = dtls13_client_server_with_max_queue(1);
+
+    server
+        .handle_packet(&dtls13_future_epoch_ciphertext(0))
+        .expect("pre-handshake future-epoch ciphertext should be tolerated");
+
+    dtls13_server_responds_to_client_hello(&mut client, &mut server, now);
+}
+
+#[test]
+#[cfg(feature = "rcgen")]
+fn dtls13_prehandshake_plaintext_non_client_hello_records_do_not_block_client_hello() {
+    let _ = env_logger::try_init();
+    let (mut client, mut server, now) = dtls13_client_server_with_max_queue(1);
+
+    server
+        .handle_packet(&dtls13_ack_record(0))
+        .expect("pre-handshake ACK should not occupy receive queue");
+
+    dtls13_server_responds_to_client_hello(&mut client, &mut server, now);
+}
+
 #[test]
 #[cfg(feature = "rcgen")]
 fn dtls13_malformed_datagram_is_discarded_without_processing_alerts() {


### PR DESCRIPTION
Before a server has accepted a `ClientHello`, records that cannot be useful at
that stage could still occupy receive-queue slots. A run of future-epoch or
otherwise non-ClientHello records could fill the queue before a valid
`ClientHello` arrives.

This filters records in the pre-ClientHello server path before they are queued:
DTLS 1.2 keeps only epoch-0 alerts and current-or-previous ClientHello
handshakes, and DTLS 1.3 keeps only plaintext alerts and current-or-previous
ClientHello handshakes. Filtered records still count against the raw
per-datagram parsed-record cap.

The auto-server fallback path retains only sanitized ClientHello-shaped packets
needed for later fallback, with the retained-packet cap checked before parsing
can mutate the DTLS 1.3 engine.

This keeps the change to the pre-ClientHello queue filter. It does not change
public error taxonomy, queue-full semantics, or broader malformed-tail/replay
policy.

Line delta:

| area | added | removed |
| --- | ---: | ---: |
| non-test code | 241 | 36 |
| tests | 204 | 0 |
| docs/changelog | 1 | 0 |
| total | 446 | 36 |

Validation:

- `git diff --check`
- `cargo fmt --check`
- `cargo test --all-targets --features rcgen`
- `cargo clippy --all-targets --features rcgen -- -D warnings`
- `/home/ronen/.codex/skills/dimpl/scripts/check-snowflake-local.pl upstream/main`
- `cargo test --no-default-features --features rust-crypto`
- `cargo clippy --no-default-features --features rust-crypto -- -D warnings`
- `cargo test --doc --features rcgen`
