### PR TITLE
dtls: replace protocol_version() with the NegotiatedVersion event

### DIFF
--- a/src/dtls12/client.rs
+++ b/src/dtls12/client.rs
@@ -86,6 +86,7 @@ pub struct Client {
 pub(crate) enum LocalEvent {
     PeerCert,
     Connected,
+    NegotiatedVersion(ProtocolVersion),
     KeyingMaterial(ArrayVec<u8, 88>, SrtpProfile),
 }
 
@@ -1143,6 +1144,9 @@ impl State {
 
         // Emit Connected event
         client.local_events.push_back(LocalEvent::Connected);
+        client
+            .local_events
+            .push_back(LocalEvent::NegotiatedVersion(ProtocolVersion::DTLS1_2));
 
         // Extract and emit SRTP keying material if we have a negotiated profile
         if let Some(profile) = client.negotiated_srtp_profile {
@@ -1388,6 +1392,7 @@ impl LocalEvent {
                 Output::PeerCert(&buf[..l])
             }
             LocalEvent::Connected => Output::Connected,
+            LocalEvent::NegotiatedVersion(v) => Output::NegotiatedVersion(v),
             LocalEvent::KeyingMaterial(m, profile) => {
                 Output::KeyingMaterial(KeyingMaterial::new(&m), profile)
             }

--- a/src/dtls12/server.rs
+++ b/src/dtls12/server.rs
@@ -1075,6 +1075,9 @@ impl State {
         // Handshake complete
         debug!("Handshake complete; ready for application data");
         server.local_events.push_back(LocalEvent::Connected);
+        server
+            .local_events
+            .push_back(LocalEvent::NegotiatedVersion(ProtocolVersion::DTLS1_2));
 
         // Emit SRTP keying material if negotiated
         if let Some(profile) = server.negotiated_srtp_profile {

--- a/src/dtls13/client.rs
+++ b/src/dtls13/client.rs
@@ -131,6 +131,7 @@ pub struct Client {
 pub(crate) enum LocalEvent {
     PeerCert,
     Connected,
+    NegotiatedVersion(ProtocolVersion),
     KeyingMaterial(ArrayVec<u8, 88>, SrtpProfile),
 }
 
@@ -1051,6 +1052,9 @@ impl State {
 
         // Emit Connected event
         client.local_events.push_back(LocalEvent::Connected);
+        client
+            .local_events
+            .push_back(LocalEvent::NegotiatedVersion(ProtocolVersion::DTLS1_3));
 
         // Extract and emit SRTP keying material if negotiated
         if let Some(profile) = client.negotiated_srtp_profile {
@@ -1559,6 +1563,7 @@ impl LocalEvent {
                 Output::PeerCert(&buf[..l])
             }
             LocalEvent::Connected => Output::Connected,
+            LocalEvent::NegotiatedVersion(v) => Output::NegotiatedVersion(v),
             LocalEvent::KeyingMaterial(m, profile) => {
                 Output::KeyingMaterial(KeyingMaterial::new(&m), profile)
             }

--- a/src/dtls13/server.rs
+++ b/src/dtls13/server.rs
@@ -1133,6 +1133,9 @@ impl State {
 
         // Emit Connected event
         server.local_events.push_back(LocalEvent::Connected);
+        server
+            .local_events
+            .push_back(LocalEvent::NegotiatedVersion(ProtocolVersion::DTLS1_3));
 
         // Extract and emit SRTP keying material if negotiated
         if let Some(profile) = server.negotiated_srtp_profile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
 //! - `Packet(&[u8])`: send on your UDP socket
 //! - `Timeout(Instant)`: schedule a timer and call `handle_timeout` at/after it
 //! - `Connected`: handshake complete
+//! - `NegotiatedVersion(ProtocolVersion)`: the DTLS version that was negotiated
 //! - `PeerCert(&[u8])`: peer leaf certificate (DER) — validate in your app
 //! - `KeyingMaterial(KeyingMaterial, SrtpProfile)`: DTLS‑SRTP export
 //! - `ApplicationData(&[u8])`: plaintext received from peer
@@ -116,6 +117,9 @@
 //!                 Output::Timeout(t) => { next_wake = Some(t); break; }
 //!                 Output::Connected => {
 //!                     // DTLS established — application may start sending
+//!                 }
+//!                 Output::NegotiatedVersion(_v) => {
+//!                     // Inspect the negotiated DTLS protocol version if desired
 //!                 }
 //!                 Output::PeerCert(_der) => {
 //!                     // Inspect peer leaf certificate if desired
@@ -529,26 +533,6 @@ impl Dtls {
         Dtls { inner: Some(inner) }
     }
 
-    /// Returns the negotiated DTLS protocol version.
-    ///
-    /// Returns `None` for auto-sense instances that have not yet completed
-    /// version negotiation (i.e. still in a `Pending` state).
-    pub fn protocol_version(&self) -> Option<ProtocolVersion> {
-        match self.inner.as_ref()? {
-            Inner::Client12(_) | Inner::Server12(_) => Some(ProtocolVersion::DTLS1_2),
-            Inner::Client13(_) => Some(ProtocolVersion::DTLS1_3),
-            Inner::Server13(s) => {
-                // Still waiting for a complete ClientHello
-                if s.is_auto_mode() {
-                    None
-                } else {
-                    Some(ProtocolVersion::DTLS1_3)
-                }
-            }
-            Inner::ClientPending(_) => None,
-        }
-    }
-
     /// Return true if the instance is operating in the client role.
     pub fn is_active(&self) -> bool {
         matches!(
@@ -846,6 +830,12 @@ pub enum Output<'a> {
     Timeout(Instant),
     /// The handshake completed and the connection is established.
     Connected,
+    /// The negotiated DTLS protocol version.
+    ///
+    /// Emitted exactly once per connection, immediately after
+    /// [`Output::Connected`]. The value is always a concrete protocol
+    /// version (`DTLS1_2` or `DTLS1_3`).
+    NegotiatedVersion(ProtocolVersion),
     /// The peer's leaf certificate in DER encoding.
     ///
     /// Applications must validate this certificate independently (chain,
@@ -865,6 +855,7 @@ impl fmt::Debug for Output<'_> {
             Self::Packet(v) => write!(f, "Packet({})", v.len()),
             Self::Timeout(v) => write!(f, "Timeout({:?})", v),
             Self::Connected => write!(f, "Connected"),
+            Self::NegotiatedVersion(v) => write!(f, "NegotiatedVersion({:?})", v),
             Self::PeerCert(v) => write!(f, "PeerCert({})", v.len()),
             Self::KeyingMaterial(v, p) => write!(f, "KeyingMaterial({}, {:?})", v.len(), p),
             Self::ApplicationData(v) => write!(f, "ApplicationData({})", v.len()),
@@ -1031,24 +1022,6 @@ mod test {
         is_unwind_safe(new_instance());
         is_unwind_safe(new_instance_13());
         is_unwind_safe(new_instance_auto());
-    }
-
-    #[test]
-    fn test_protocol_version_12() {
-        let dtls = new_instance();
-        assert_eq!(dtls.protocol_version(), Some(ProtocolVersion::DTLS1_2));
-    }
-
-    #[test]
-    fn test_protocol_version_13() {
-        let dtls = new_instance_13();
-        assert_eq!(dtls.protocol_version(), Some(ProtocolVersion::DTLS1_3));
-    }
-
-    #[test]
-    fn test_protocol_version_auto_pending() {
-        let dtls = new_instance_auto();
-        assert_eq!(dtls.protocol_version(), None);
     }
 
     #[test]

--- a/tests/auto/common.rs
+++ b/tests/auto/common.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use dimpl::{Config, Dtls, Output, SrtpProfile};
+use dimpl::{Config, Dtls, Output, ProtocolVersion, SrtpProfile};
 
 /// Collected outputs from polling an endpoint to `Timeout`.
 #[derive(Default, Debug)]
@@ -17,6 +17,7 @@ pub struct DrainedOutputs {
     pub app_data: Vec<Vec<u8>>,
     pub timeout: Option<Instant>,
     pub close_notify: bool,
+    pub negotiated_version: Option<ProtocolVersion>,
 }
 
 /// Poll until `Timeout`, collecting only packets.
@@ -41,6 +42,7 @@ pub fn drain_outputs(endpoint: &mut Dtls) -> DrainedOutputs {
         match endpoint.poll_output(&mut buf) {
             Output::Packet(p) => result.packets.push(p.to_vec()),
             Output::Connected => result.connected = true,
+            Output::NegotiatedVersion(v) => result.negotiated_version = Some(v),
             Output::PeerCert(cert) => result.peer_cert = Some(cert.to_vec()),
             Output::KeyingMaterial(km, profile) => {
                 result.keying_material = Some((km.to_vec(), profile));

--- a/tests/auto/cross_matrix.rs
+++ b/tests/auto/cross_matrix.rs
@@ -61,6 +61,8 @@ fn try_handshake(
     let mut now = Instant::now();
     let mut cc = false;
     let mut sc = false;
+    let mut cv: Option<ProtocolVersion> = None;
+    let mut sv: Option<ProtocolVersion> = None;
 
     for _ in 0..80 {
         if client.handle_timeout(now).is_err() {
@@ -79,6 +81,12 @@ fn try_handshake(
         if so.connected {
             sc = true;
         }
+        if let Some(v) = co.negotiated_version {
+            cv = Some(v);
+        }
+        if let Some(v) = so.negotiated_version {
+            sv = Some(v);
+        }
 
         // Deliver packets, ignoring errors (incompatible version → errors are expected)
         for p in &co.packets {
@@ -89,10 +97,7 @@ fn try_handshake(
         }
 
         if cc && sc {
-            return Some((
-                client.protocol_version().unwrap(),
-                server.protocol_version().unwrap(),
-            ));
+            return Some((cv.unwrap(), sv.unwrap()));
         }
 
         now += Duration::from_millis(10);

--- a/tests/auto/handshake.rs
+++ b/tests/auto/handshake.rs
@@ -599,9 +599,9 @@ fn auto_client_rejects_unknown_version_response() {
 
 #[test]
 #[cfg(feature = "rcgen")]
-fn auto_client_protocol_version_after_negotiating_dtls13() {
+fn auto_client_negotiated_version_after_negotiating_dtls13() {
     //! After completing a handshake against a DTLS 1.3 server, the
-    //! auto-sense client should report `Some(ProtocolVersion::DTLS1_3)`.
+    //! auto-sense client should emit `Output::NegotiatedVersion(DTLS1_3)`.
     use dimpl::ProtocolVersion;
     use dimpl::certificate::generate_self_signed_certificate;
 
@@ -619,11 +619,9 @@ fn auto_client_protocol_version_after_negotiating_dtls13() {
     let mut server = Dtls::new_13(config, server_cert, now);
     server.set_active(false);
 
-    // Before negotiation, auto-sense returns None.
-    assert_eq!(client.protocol_version(), None);
-
     let mut client_connected = false;
     let mut server_connected = false;
+    let mut client_ver: Option<ProtocolVersion> = None;
 
     for _ in 0..40 {
         client.handle_timeout(now).expect("client timeout");
@@ -637,6 +635,9 @@ fn auto_client_protocol_version_after_negotiating_dtls13() {
         }
         if server_out.connected {
             server_connected = true;
+        }
+        if let Some(v) = client_out.negotiated_version {
+            client_ver = Some(v);
         }
 
         deliver_packets(&client_out.packets, &mut server);
@@ -652,14 +653,14 @@ fn auto_client_protocol_version_after_negotiating_dtls13() {
         client_connected && server_connected,
         "Handshake should complete"
     );
-    assert_eq!(client.protocol_version(), Some(ProtocolVersion::DTLS1_3));
+    assert_eq!(client_ver, Some(ProtocolVersion::DTLS1_3));
 }
 
 #[test]
 #[cfg(feature = "rcgen")]
-fn auto_client_protocol_version_after_negotiating_dtls12() {
+fn auto_client_negotiated_version_after_negotiating_dtls12() {
     //! After completing a handshake against a DTLS 1.2 server, the
-    //! auto-sense client should report `Some(ProtocolVersion::DTLS1_2)`.
+    //! auto-sense client should emit `Output::NegotiatedVersion(DTLS1_2)`.
     use dimpl::ProtocolVersion;
     use dimpl::certificate::generate_self_signed_certificate;
 
@@ -677,11 +678,9 @@ fn auto_client_protocol_version_after_negotiating_dtls12() {
     let mut server = Dtls::new_12(config, server_cert, now);
     server.set_active(false);
 
-    // Before negotiation, auto-sense returns None.
-    assert_eq!(client.protocol_version(), None);
-
     let mut client_connected = false;
     let mut server_connected = false;
+    let mut client_ver: Option<ProtocolVersion> = None;
 
     for _ in 0..40 {
         client.handle_timeout(now).expect("client timeout");
@@ -695,6 +694,9 @@ fn auto_client_protocol_version_after_negotiating_dtls12() {
         }
         if server_out.connected {
             server_connected = true;
+        }
+        if let Some(v) = client_out.negotiated_version {
+            client_ver = Some(v);
         }
 
         deliver_packets(&client_out.packets, &mut server);
@@ -710,5 +712,5 @@ fn auto_client_protocol_version_after_negotiating_dtls12() {
         client_connected && server_connected,
         "Handshake should complete"
     );
-    assert_eq!(client.protocol_version(), Some(ProtocolVersion::DTLS1_2));
+    assert_eq!(client_ver, Some(ProtocolVersion::DTLS1_2));
 }

--- a/tests/auto/server_fallback.rs
+++ b/tests/auto/server_fallback.rs
@@ -20,6 +20,8 @@ fn run_handshake(
     let mut now = Instant::now();
     let mut client_connected = false;
     let mut server_connected = false;
+    let mut client_ver: Option<ProtocolVersion> = None;
+    let mut server_ver: Option<ProtocolVersion> = None;
 
     for _ in 0..80 {
         client.handle_timeout(now).expect("client timeout");
@@ -34,6 +36,12 @@ fn run_handshake(
         if server_out.connected {
             server_connected = true;
         }
+        if let Some(v) = client_out.negotiated_version {
+            client_ver = Some(v);
+        }
+        if let Some(v) = server_out.negotiated_version {
+            server_ver = Some(v);
+        }
 
         deliver_packets(&client_out.packets, server);
         deliver_packets(&server_out.packets, client);
@@ -45,12 +53,7 @@ fn run_handshake(
         now += Duration::from_millis(10);
     }
 
-    (
-        client_connected,
-        server_connected,
-        client.protocol_version(),
-        server.protocol_version(),
-    )
+    (client_connected, server_connected, client_ver, server_ver)
 }
 
 // ============================================================================
@@ -108,30 +111,6 @@ fn auto_server_send_application_data_pending() {
 
     assert!(cc, "Client should connect after pending send");
     assert!(sc, "Server should connect after pending send");
-    assert_eq!(cv, Some(ProtocolVersion::DTLS1_2));
-    assert_eq!(sv, Some(ProtocolVersion::DTLS1_2));
-}
-
-#[test]
-#[cfg(feature = "rcgen")]
-fn auto_server_protocol_version_pending() {
-    use dimpl::certificate::generate_self_signed_certificate;
-
-    let client_cert = generate_self_signed_certificate().unwrap();
-    let server_cert = generate_self_signed_certificate().unwrap();
-    let config = default_config();
-
-    let mut client = Dtls::new_12(Arc::clone(&config), client_cert, Instant::now());
-    client.set_active(true);
-
-    let mut server = Dtls::new_auto(config, server_cert, Instant::now());
-
-    assert_eq!(server.protocol_version(), None);
-
-    let (cc, sc, cv, sv) = run_handshake(&mut client, &mut server);
-
-    assert!(cc, "Client should connect after pending protocol check");
-    assert!(sc, "Server should connect after pending protocol check");
     assert_eq!(cv, Some(ProtocolVersion::DTLS1_2));
     assert_eq!(sv, Some(ProtocolVersion::DTLS1_2));
 }


### PR DESCRIPTION
As discussed in https://github.com/algesten/str0m/issues/960, here's the dimpl PR of exposing the negotiated DTLS protocol version via an event. 
There was protocol_version() function, but it was not used so I decided to remove it.