### PR TITLE
Add changelog entry for handshake defragment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+  * Fix DTLS handshake defragmentation across message sequences #151
   * Return `BufferTooSmall` instead of panicking on undersized poll buffers #150
   * Fix DTLS 1.3 RFC 9147 conformance issues #147
   * Reject malformed fragmented DTLS handshakes before consuming fragments #144


### PR DESCRIPTION
Summary

- Document the DTLS handshake defragmentation sequence-grouping fix in the Unreleased changelog.